### PR TITLE
Skip Add Simulation Popup

### DIFF
--- a/python/panels/panel_overview.py
+++ b/python/panels/panel_overview.py
@@ -85,6 +85,8 @@ are completely separate from each other."""
         return {"FINISHED"}
 
     def invoke(self, context, _):
+        if not context.scene.squishy_volumes_scene.tutorial_active:
+            return self.execute(context)
         return context.window_manager.invoke_props_dialog(self)
 
     def draw(self, context):


### PR DESCRIPTION
Small convenience feature.

The pop-up for adding a simulation isn't handy.
Except for displaying the tutorial message.