### PR TITLE
Mac Compatible Profiling

### DIFF
--- a/rust/crates/gpu/src/context.rs
+++ b/rust/crates/gpu/src/context.rs
@@ -33,12 +33,15 @@ pub struct GpuContext {
     indirect_allocator: Option<GpuAllocator>,
 }
 
-fn requirements() -> (wgpu::Features, wgpu::Limits) {
+fn requirements(enable_scope_profiling: bool) -> (wgpu::Features, wgpu::Limits) {
     let mut features = wgpu::Features::empty();
     features |= wgpu::Features::SUBGROUP;
     features |= wgpu::Features::IMMEDIATES;
     features |= wgpu::Features::TIMESTAMP_QUERY;
-    features |= wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
+
+    if enable_scope_profiling {
+        features |= wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
+    }
 
     let mut limits = wgpu::Limits::downlevel_defaults();
     limits.max_immediate_size = 4;
@@ -75,7 +78,17 @@ impl GpuContext {
             .then_some(())
             .ok_or(GpuError::ComputeNotSupported)?;
 
-        let (required_features, mut required_limits) = requirements();
+        let enable_scope_profiling = adapter
+            .features()
+            .contains(wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS);
+        if !enable_scope_profiling {
+            tracing::warn!(
+                "Missing {:?}, GPU profiling is limited.",
+                wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS
+            )
+        }
+
+        let (required_features, mut required_limits) = requirements(enable_scope_profiling);
         required_limits.max_buffer_size = max_buffer_size;
         required_limits.max_storage_buffer_binding_size = max_storage_buffer_binding_size;
         tracing::info!(

--- a/rust/crates/gpu/src/gpu_state.rs
+++ b/rust/crates/gpu/src/gpu_state.rs
@@ -155,7 +155,7 @@ impl GpuState {
         };
 
         let profile_data_csv_writer = profiling_output_file
-            .map(|path| ProfileDataCsvWriter::new(path))
+            .map(ProfileDataCsvWriter::new)
             .transpose()?;
 
         harness.check()?;

--- a/rust/crates/gpu/src/gpu_state.rs
+++ b/rust/crates/gpu/src/gpu_state.rs
@@ -327,6 +327,7 @@ impl GpuState {
         let mut profiler =
             wgpu_profiler::GpuProfiler::new(self.gpu_context.device(), Default::default()).unwrap();
 
+        let mut times = Vec::new();
         let mut recorded_steps = 0;
         let output = loop {
             harness.check()?;
@@ -341,6 +342,7 @@ impl GpuState {
                     factor: frame_input.frame_factor(self.time)?,
                 },
             )?;
+            times.push(self.time);
             self.time += self.time_step as f64;
 
             recorded_steps += 1;
@@ -456,15 +458,6 @@ impl GpuState {
             }
         }
 
-        // TODO: what if the frame needs to be redone?
-        if let Some(profile_data_csv_writer) = self.profile_data_csv_writer.as_mut() {
-            profile_data_csv_writer.write_frame(
-                &self.gpu_context,
-                &mut profiler,
-                frame_input.frame(),
-            )?;
-        }
-
         tracing::info!("download");
 
         let [
@@ -518,6 +511,10 @@ impl GpuState {
                     store_grid,
                 },
             );
+        }
+
+        if let Some(profile_data_csv_writer) = self.profile_data_csv_writer.as_mut() {
+            profile_data_csv_writer.write_frame(&self.gpu_context, &mut profiler, &times)?;
         }
 
         let particle_positions_and_collider_bits: Vec<PositionAndColliderBits> =

--- a/rust/crates/gpu/src/pipeline_part.rs
+++ b/rust/crates/gpu/src/pipeline_part.rs
@@ -38,6 +38,7 @@ impl CommandEncoder<'_> {
     pub fn scope<'a>(&'a mut self, label: Option<&'static str>) -> CommandEncoder<'a> {
         match self {
             CommandEncoder::Encoder(command_encoder) => CommandEncoder::Encoder(command_encoder),
+            // Note that this will do nothing without TIMESTAMP_QUERY_INSIDE_ENCODERS
             CommandEncoder::Scoped(scope) => {
                 CommandEncoder::Scoped(scope.scope(label.unwrap_or("unlabled")))
             }

--- a/rust/crates/gpu/src/profiler_output.rs
+++ b/rust/crates/gpu/src/profiler_output.rs
@@ -15,6 +15,7 @@ use std::{
 
 use super::GpuContext;
 
+use iter_enumeration::IntoIterEnum2;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -34,6 +35,9 @@ pub enum ProfilerError {
         labels: Vec<String>,
     },
 
+    #[error("Recorded {steps} steps, but the labels aren't a multiple of that {labels:?}")]
+    NotMultipleOfRecordedSteps { steps: usize, labels: Vec<String> },
+
     #[error("IoError: {0}")]
     IoError(#[from] io::Error),
 }
@@ -42,21 +46,24 @@ fn get_profiling_data(
     context: &GpuContext,
     profiler: &mut wgpu_profiler::GpuProfiler,
 ) -> Result<Vec<(String, Range<f64>)>, ProfilerError> {
-    profiler
+    fn result_to_data(
+        result: wgpu_profiler::GpuTimerQueryResult,
+    ) -> Box<dyn Iterator<Item = (String, Range<f64>)>> {
+        Box::new(
+            if let Some(time) = result.time {
+                std::iter::once((result.label, time)).iter_enum_2a()
+            } else {
+                std::iter::empty().iter_enum_2b()
+            }
+            .chain(result.nested_queries.into_iter().flat_map(result_to_data)),
+        )
+    }
+
+    let frame = profiler
         .process_finished_frame(context.queue().get_timestamp_period())
-        .ok_or(ProfilerError::NoFinishedFrame)?
-        .first()
-        .ok_or(ProfilerError::ResultsEmpty)?
-        .nested_queries
-        .iter()
-        .cloned()
-        .map(|query| {
-            Ok((
-                query.label,
-                query.time.ok_or(ProfilerError::NoTimeRecorded)?,
-            ))
-        })
-        .collect()
+        .ok_or(ProfilerError::NoFinishedFrame)?;
+
+    Ok(frame.into_iter().flat_map(result_to_data).collect())
 }
 
 pub fn profiler_output(
@@ -101,10 +108,40 @@ impl ProfileDataCsvWriter {
         &mut self,
         context: &GpuContext,
         profiler: &mut wgpu_profiler::GpuProfiler,
-        frame: usize,
+        times: &[f64],
     ) -> Result<(), ProfilerError> {
         let profiling_data = get_profiling_data(context, profiler)?;
+        if profiling_data.is_empty() {
+            return Err(ProfilerError::ResultsEmpty);
+        }
 
+        if !profiling_data.len().is_multiple_of(times.len()) {
+            return Err(ProfilerError::NotMultipleOfRecordedSteps {
+                steps: times.len(),
+                labels: profiling_data
+                    .into_iter()
+                    .map(|label_and_range| label_and_range.0)
+                    .collect(),
+            });
+        }
+
+        for (&time, profiling_data) in times
+            .iter()
+            .zip(profiling_data.chunks(profiling_data.len() / times.len()))
+        {
+            self.write_step(time, profiling_data)?;
+        }
+
+        self.writer.flush()?;
+
+        Ok(())
+    }
+
+    fn write_step(
+        &mut self,
+        time: f64,
+        profiling_data: &[(String, Range<f64>)],
+    ) -> Result<(), ProfilerError> {
         let labels: Vec<String> = profiling_data
             .iter()
             .map(|(label, _)| label.clone())
@@ -126,7 +163,7 @@ impl ProfileDataCsvWriter {
             .map(|(_, range)| range.start)
             .ok_or(ProfilerError::ResultsEmpty)?;
 
-        write!(self.writer, "{frame}")?;
+        write!(self.writer, "{time}")?;
         for (_, range) in profiling_data {
             write!(
                 self.writer,
@@ -136,13 +173,12 @@ impl ProfileDataCsvWriter {
             )?;
         }
         writeln!(self.writer)?;
-        self.writer.flush()?;
 
         Ok(())
     }
 
     fn write_header(&mut self, labels: &[String]) -> Result<(), ProfilerError> {
-        write!(self.writer, "frame")?;
+        write!(self.writer, "time")?;
 
         for label in labels {
             let name = gnuplot_name(label);

--- a/scripts/band_plot_profile.py
+++ b/scripts/band_plot_profile.py
@@ -10,30 +10,30 @@ parser.add_argument("output")
 args = parser.parse_args()
 
 
-frames = []
 labels = []
 values = []
 with open(args.input) as csvfile:
     reader = csv.reader(csvfile, delimiter=",")
     for row in reader:
         if not labels:
-            labels = row[1:]
+            labels = row
             for _ in range(len(labels)):
                 values.append([])
             continue
 
-        frames.append(int(row[0]))
-        for i, value in enumerate(row[1:]):
+        for i, value in enumerate(row):
             values[i].append(float(value))
+
+assert labels[0] == "time"
 
 fig = go.Figure()
 
-for i in range(len(labels) // 2):
-    start = i * 2
-    end = i * 2 + 1
+for i in range((len(labels) - 1) // 2):
+    start = i * 2 + 1
+    end = i * 2 + 2
     fig.add_trace(
         go.Scatter(
-            x=frames,
+            x=values[0],
             y=values[start],
             mode="lines",
             fill=None,
@@ -43,7 +43,7 @@ for i in range(len(labels) // 2):
     )
     fig.add_trace(
         go.Scatter(
-            x=frames, y=values[end], mode="lines", fill="tonexty", name=labels[start]
+            x=values[0], y=values[end], mode="lines", fill="tonexty", name=labels[start]
         )
     )
 

--- a/scripts/bar_plot_profile.py
+++ b/scripts/bar_plot_profile.py
@@ -10,26 +10,29 @@ parser.add_argument("output")
 args = parser.parse_args()
 
 
-frames = []
 labels = []
 values = []
 with open(args.input) as csvfile:
     reader = csv.reader(csvfile, delimiter=",")
     for row in reader:
         if not labels:
-            labels = row[1:]
+            labels = row
             del labels[1::2]
+            # drop the -end suffix
+            labels = [labels[0]] + [l[0:-4] for l in labels[1:]]
             for _ in range(len(labels)):
                 values.append([])
             continue
 
-        frames.append(int(row[0]))
-        for i in range(len(labels)):
-            values[i].append(float(row[i * 2 + 2]) - float(row[i * 2 + 1]))
+        values[0].append(float(row[0]))
+        for i in range(len(labels) - 1):
+            values[i + 1].append(float(row[i * 2 + 2]) - float(row[i * 2 + 1]))
+
+assert labels[0] == "time"
 
 fig = go.Figure()
 
-for i in range(len(labels)):
-    fig.add_trace(go.Bar(x=frames, y=values[i], name=labels[i]))
+for i in range(1, len(labels)):
+    fig.add_trace(go.Bar(x=values[0], y=values[i], name=labels[i]))
 
 fig.show()


### PR DESCRIPTION
While fixing profiling on macOS, I realized that we're not using all of the available data on Linux.
The whole picture now looks more like this:

<img width="1573" height="962" alt="newplot(1)" src="https://github.com/user-attachments/assets/74b93acc-7cb1-4852-80b8-910bdcdd0c61" />

<img width="2279" height="1354" alt="newplot(2)" src="https://github.com/user-attachments/assets/607295ee-e81c-47db-b034-da1c92b01c7a" />

Maybe we can also have this kind of plot directly in Blender!