### PR TITLE
feat: add benchmark startup scene

### DIFF
--- a/python/src/squishy_volumes_extension/panels/panel_overview.py
+++ b/python/src/squishy_volumes_extension/panels/panel_overview.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import re
 
 import bpy
@@ -56,6 +57,31 @@ from ..util import (
     locked_simulations,
     unloaded_simulations,
 )
+from ..startup import STARTUP_BENCHMARK, setup_startup_simulation
+
+
+class SCENE_OT_Squishy_Volumes_Add_Startup_Simulation(bpy.types.Operator):
+    bl_idname = "scene.squishy_volumes_add_startup_simulation"
+    bl_label = "Add Startup Simulation"
+    bl_description = """Start with a prefabricated Squishy Volumes simulation."""
+    bl_options = {"REGISTER", "UNDO"}
+
+    startup_choice: bpy.props.EnumProperty(
+        items=[
+            (STARTUP_BENCHMARK,) * 3,
+        ],  # ty:ignore[invalid-argument-type]
+        name="Chose Startup Simulation",
+        description="Chose one of the startup simulations to set up.",
+        default=STARTUP_BENCHMARK,
+        options=set(),
+    )  # type: ignore
+
+    def execute(self, context):
+        setup_startup_simulation(context, self.startup_choice)
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
 
 
 class SCENE_OT_Squishy_Volumes_Add_Simulation(bpy.types.Operator):
@@ -346,7 +372,12 @@ class SCENE_PT_Squishy_Volumes_Overview(bpy.types.Panel):
                     grid.label(text="Last frame substeps")
                     grid.label(text=f"{last_frame_substeps}")
 
-        layout.operator(SCENE_OT_Squishy_Volumes_Add_Simulation.bl_idname, icon="ADD")
+        add_row = layout.row()
+        add_row.alert = not context.scene.squishy_volumes_scene.simulations
+        add_row.operator(SCENE_OT_Squishy_Volumes_Add_Simulation.bl_idname, icon="ADD")
+        add_row.operator(
+            SCENE_OT_Squishy_Volumes_Add_Startup_Simulation.bl_idname, icon="ADD"
+        )
 
         if len(context.scene.squishy_volumes_scene.simulations) > 1:
             layout.separator()
@@ -358,6 +389,7 @@ class SCENE_PT_Squishy_Volumes_Overview(bpy.types.Panel):
 
 
 classes = [
+    SCENE_OT_Squishy_Volumes_Add_Startup_Simulation,
     SCENE_OT_Squishy_Volumes_Add_Simulation,
     SCENE_OT_Squishy_Volumes_Reload,
     SCENE_OT_Squishy_Volumes_Reload_All,

--- a/python/src/squishy_volumes_extension/panels/panel_overview.py
+++ b/python/src/squishy_volumes_extension/panels/panel_overview.py
@@ -373,7 +373,6 @@ class SCENE_PT_Squishy_Volumes_Overview(bpy.types.Panel):
                     grid.label(text=f"{last_frame_substeps}")
 
         add_row = layout.row()
-        add_row.alert = not context.scene.squishy_volumes_scene.simulations
         add_row.operator(SCENE_OT_Squishy_Volumes_Add_Simulation.bl_idname, icon="ADD")
         add_row.operator(
             SCENE_OT_Squishy_Volumes_Add_Startup_Simulation.bl_idname, icon="ADD"

--- a/python/src/squishy_volumes_extension/startup/__init__.py
+++ b/python/src/squishy_volumes_extension/startup/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of the Squishy Volumes extension.
+# Copyright (C) 2025  Algebraic UG (haftungsbeschränkt)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from .benchmark import STARTUP_BENCHMARK, setup_startup_benchmark
+
+
+def setup_startup_simulation(context, choice):
+    if choice == STARTUP_BENCHMARK:
+        return setup_startup_benchmark(context)
+    raise RuntimeError(f"Unknown startup simulation: {choice}")

--- a/python/src/squishy_volumes_extension/startup/benchmark.py
+++ b/python/src/squishy_volumes_extension/startup/benchmark.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of the Squishy Volumes extension.
+# Copyright (C) 2025  Algebraic UG (haftungsbeschränkt)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import bpy
+import uuid
+import math
+
+import tempfile
+from pathlib import Path
+
+
+from ..properties.squishy_volumes_simulation import (
+    update_name,
+    update_directory,
+)
+
+from ..properties.squishy_volumes_object_input_settings import (
+    INPUT_TYPE_PARTICLES,
+    INPUT_TYPE_COLLIDER,
+)
+
+from ..util import simulation_locked
+
+STARTUP_BENCHMARK = "Benchmark"
+
+
+def setup_startup_benchmark(context: bpy.types.Context):
+    bpy.ops.scene.squishy_volumes_add_simulation("INVOKE_DEFAULT")  # ty: ignore[unresolved-attribute]
+
+    simulation = context.scene.squishy_volumes_scene.simulations[-1]
+
+    simulation.name = STARTUP_BENCHMARK
+    simulation.directory = str(
+        Path(tempfile.gettempdir()) / f"squishy_volumes_{STARTUP_BENCHMARK}"
+    )
+
+    simulation.grid_node_size = 0.1
+    simulation.time_step = 0.001
+    simulation.capture_frames = 1
+    simulation.bake_frames = 60
+    simulation.immediately_start_baking = False
+
+    input_particles = []
+    input_collider = []
+
+    bpy.ops.mesh.primitive_monkey_add(
+        size=4,
+        enter_editmode=False,
+        align="WORLD",
+        location=(-2, -2, 0),
+        scale=(1, 1, 1),
+        rotation=(math.radians(-45), 0, math.radians(135)),
+    )
+    input_particles.append(context.active_object.name)
+
+    bpy.ops.mesh.primitive_monkey_add(
+        size=4,
+        enter_editmode=False,
+        align="WORLD",
+        location=(-2, 2, 0),
+        scale=(1, 1, 1),
+        rotation=(math.radians(-45), 0, math.radians(45)),
+    )
+    input_particles.append(context.active_object.name)
+
+    bpy.ops.mesh.primitive_monkey_add(
+        size=4,
+        enter_editmode=False,
+        align="WORLD",
+        location=(2, 2, 0),
+        scale=(1, 1, 1),
+        rotation=(math.radians(-45), 0, math.radians(-45)),
+    )
+    input_particles.append(context.active_object.name)
+
+    bpy.ops.mesh.primitive_monkey_add(
+        size=4,
+        enter_editmode=False,
+        align="WORLD",
+        location=(2, -2, 0),
+        scale=(1, 1, 1),
+        rotation=(math.radians(-45), 0, math.radians(-135)),
+    )
+    input_particles.append(context.active_object.name)
+
+    bpy.ops.mesh.primitive_monkey_add(
+        size=4,
+        enter_editmode=False,
+        align="WORLD",
+        location=(-2, -2, 4),
+        scale=(1, 1, 1),
+        rotation=(math.radians(-45), 0, math.radians(135)),
+    )
+    input_particles.append(context.active_object.name)
+
+    bpy.ops.mesh.primitive_monkey_add(
+        size=4,
+        enter_editmode=False,
+        align="WORLD",
+        location=(-2, 2, 4),
+        scale=(1, 1, 1),
+        rotation=(math.radians(-45), 0, math.radians(45)),
+    )
+    input_particles.append(context.active_object.name)
+
+    bpy.ops.mesh.primitive_monkey_add(
+        size=4,
+        enter_editmode=False,
+        align="WORLD",
+        location=(2, 2, 4),
+        scale=(1, 1, 1),
+        rotation=(math.radians(-45), 0, math.radians(-45)),
+    )
+    input_particles.append(context.active_object.name)
+
+    bpy.ops.mesh.primitive_monkey_add(
+        size=4,
+        enter_editmode=False,
+        align="WORLD",
+        location=(2, -2, 4),
+        scale=(1, 1, 1),
+        rotation=(math.radians(-45), 0, math.radians(-135)),
+    )
+    input_particles.append(context.active_object.name)
+
+    bpy.ops.mesh.primitive_cone_add(
+        radius1=2,
+        depth=4,
+        enter_editmode=False,
+        align="WORLD",
+        location=(0, 0, -2),
+        scale=(1, 1, 1),
+    )
+    input_collider.append(context.active_object.name)
+
+    bpy.ops.mesh.primitive_torus_add(
+        align="WORLD",
+        location=(0, 0, -3),
+        rotation=(0, 0, 0),
+        major_radius=4,
+        minor_radius=1,
+    )
+    input_collider.append(context.active_object.name)
+
+    bpy.ops.mesh.primitive_plane_add(
+        enter_editmode=False,
+        align="WORLD",
+        location=(0, 0, -10),
+        scale=(1, 1, 1),
+        size=100,
+    )
+    input_collider.append(context.active_object.name)
+
+    for name in input_particles:
+        obj = bpy.data.objects[name]
+        obj.squishy_volumes_object.input_settings.input_type = INPUT_TYPE_PARTICLES
+        obj.select_set(True)
+
+    for name in input_collider:
+        obj = bpy.data.objects[name]
+        obj.squishy_volumes_object.input_settings.input_type = INPUT_TYPE_COLLIDER
+        obj.select_set(True)
+
+    bpy.ops.scene.squishy_volumes_add_input_objects()
+    bpy.ops.scene.squishy_volumes_write_input_to_cache(  # ty:ignore[unresolved-attribute]
+        uuid=simulation.uuid, blocking=True
+    )
+
+    for name in input_particles:
+        bpy.ops.scene.squishy_volumes_add_output_objects(
+            uuid=simulation.uuid,
+            called_from_script=True,
+            input_name=name,
+        )
+
+    simulation.immediately_start_baking = True
+    bpy.ops.scene.squishy_volumes_bake_start_from_latest()


### PR DESCRIPTION
The UI is blocked for a few seconds, and the setup is a bit brittle if the user has already created some other simulations.
These issues can be fixed in future PRs.

The 8 Suzannes each make up 134k particles for a total of a bit more than 1 million particles.
Time step is set to 0.001 seconds.

The computation took 45 seconds on RTX 4070.
A few more measurement tools are in order.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/8ed3e3c3-6498-4537-94be-ab935bc28521" />