### PR TITLE
fix: leaky mesh due to open vertex

### DIFF
--- a/rust/crates/gpu/src/animate_mesh/mod.rs
+++ b/rust/crates/gpu/src/animate_mesh/mod.rs
@@ -39,7 +39,7 @@ pub struct Input {
     pub vertex_positions_start: Allocation,
     pub vertex_positions_end: Allocation,
     pub vertex_triangle_offsets: Allocation,
-    pub vertex_triangle_lists: Allocation,
+    pub vertex_triangle_lists: Option<Allocation>,
     pub triangle_indices: Allocation,
 }
 
@@ -75,13 +75,10 @@ impl Input {
                 .map(|v| v.len() as u32)
                 .collect::<Vec<_>>(),
         );
-        let mut vertex_triangle_lists = vertex_triangle_lists
+        let vertex_triangle_lists = vertex_triangle_lists
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();
-        if vertex_triangle_lists.is_empty() {
-            vertex_triangle_lists.push(0);
-        }
 
         let vertex_positions_start =
             Allocation::new(device, "vertex_positions_start", vertex_positions_start)?;
@@ -89,8 +86,9 @@ impl Input {
             Allocation::new(device, "vertex_positions_end", vertex_positions_end)?;
         let vertex_triangle_offsets =
             Allocation::new(device, "vertex_triangle_offsets", &vertex_triangle_offsets)?;
-        let vertex_triangle_lists =
-            Allocation::new(device, "vertex_triangle_lists", &vertex_triangle_lists)?;
+        let vertex_triangle_lists = (!vertex_triangle_lists.is_empty())
+            .then(|| Allocation::new(device, "vertex_triangle_lists", &vertex_triangle_lists))
+            .transpose()?;
 
         let triangle_indices = Allocation::new(device, "triangle_indices", triangle_indices)?;
 
@@ -241,7 +239,7 @@ impl PipelinePart for AnimateMesh {
                 .dispatch_workgroups(x, y, z);
         }
 
-        {
+        if let Some(vertex_triangle_lists) = vertex_triangle_lists.as_ref() {
             let [x, y, z] = Indirect::new(DispatchSettings {
                 workgroup_size: self.workgroup_size,
                 dispatch_limit: self.dispatch_limit,
@@ -261,6 +259,12 @@ impl PipelinePart for AnimateMesh {
                     ],
                 )
                 .dispatch_workgroups(x, y, z);
+        } else {
+            encoder.scope(Some("zero_vertex_normals")).clear_buffer(
+                vertex_normals.buffer(),
+                vertex_normals.offset(),
+                Some(vertex_normals.size().get()),
+            );
         }
 
         Ok(Output {

--- a/rust/crates/gpu/src/gpu_state.rs
+++ b/rust/crates/gpu/src/gpu_state.rs
@@ -248,14 +248,10 @@ fn get_collider_input(
             .map(|v| v.len() as u32)
             .collect::<Vec<_>>(),
     );
-    let mut vertex_triangle_lists: Vec<u32> = vertex_triangle_lists
+    let vertex_triangle_lists: Vec<u32> = vertex_triangle_lists
         .iter()
         .flat_map(|list| list.iter().cloned())
         .collect();
-    if vertex_triangle_lists.is_empty() {
-        tracing::warn!("all vertices are on open edges");
-        vertex_triangle_lists.push(0);
-    }
 
     tracing::info!("creating mesh allocations");
     let vertex_positions_start =
@@ -264,8 +260,16 @@ fn get_collider_input(
         Allocation::new(device, "vertex_positions_end", &vertex_positions_end)?;
     let vertex_triangle_offsets =
         Allocation::new(device, "vertex_triangle_offsets", &vertex_triangle_offsets)?;
-    let vertex_triangle_lists =
-        Allocation::new(device, "vertex_triangle_lists", &vertex_triangle_lists)?;
+    let vertex_triangle_lists = if vertex_triangle_lists.is_empty() {
+        tracing::warn!("all vertices are on open edges");
+        None
+    } else {
+        Some(Allocation::new(
+            device,
+            "vertex_triangle_lists",
+            &vertex_triangle_lists,
+        )?)
+    };
 
     let triangle_indices =
         Allocation::new(device, "triangle_indices", topology.triangle_indices())?;

--- a/rust/crates/gpu/src/shaders/compute_vertex_normals.wesl
+++ b/rust/crates/gpu/src/shaders/compute_vertex_normals.wesl
@@ -43,7 +43,10 @@ fn main(
     }
 
     let triangle_start = vertex_triangle_offsets[global_index];
-    let triangle_end = vertex_triangle_offsets[global_index + 1];
+    var triangle_end = arrayLength(&vertex_triangle_lists);
+    if global_index + 1 < arrayLength(&vertex_triangle_offsets) {
+        triangle_end = vertex_triangle_offsets[global_index + 1];
+    }
 
     var normal = vec3f(0.);
     for (var lookup = triangle_start; lookup < triangle_end; lookup++) {

--- a/rust/crates/gpu/src/step/mod.rs
+++ b/rust/crates/gpu/src/step/mod.rs
@@ -54,7 +54,8 @@ pub struct ColliderInput {
     pub vertex_positions_start: Allocation,
     pub vertex_positions_end: Allocation,
     pub vertex_triangle_offsets: Allocation,
-    pub vertex_triangle_lists: Allocation,
+
+    pub vertex_triangle_lists: Option<Allocation>,
 
     pub triangle_indices: Allocation,
     pub triangle_collider: Allocation,
@@ -162,13 +163,10 @@ impl ColliderInput {
                 .map(|v| v.len() as u32)
                 .collect::<Vec<_>>(),
         );
-        let mut vertex_triangle_lists = vertex_triangle_lists
+        let vertex_triangle_lists = vertex_triangle_lists
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();
-        if vertex_triangle_lists.is_empty() {
-            vertex_triangle_lists.push(0);
-        }
 
         let make_aabbs = |positions: &[Vector4<f32>]| {
             triangles_to_leaf_aabbs(
@@ -192,8 +190,9 @@ impl ColliderInput {
             Allocation::new(device, "vertex_positions_end", vertex_positions_end)?;
         let vertex_triangle_offsets =
             Allocation::new(device, "vertex_triangle_offsets", &vertex_triangle_offsets)?;
-        let vertex_triangle_lists =
-            Allocation::new(device, "vertex_triangle_lists", &vertex_triangle_lists)?;
+        let vertex_triangle_lists = (!vertex_triangle_lists.is_empty())
+            .then(|| Allocation::new(device, "vertex_triangle_lists", &vertex_triangle_lists))
+            .transpose()?;
 
         let triangle_indices = Allocation::new(device, "triangle_indices", triangle_indices)?;
         let triangle_collider = Allocation::new(device, "triangle_collider", triangle_collider)?;

--- a/rust/crates/mesh_util/src/mesh.rs
+++ b/rust/crates/mesh_util/src/mesh.rs
@@ -189,9 +189,6 @@ pub fn compute_triangle_lists(
                 triangles.clear();
             }
         });
-    // this is so that range calculation via prefix sum can be used
-    // TODO: maybe that should happen at the place of use, then
-    vertex_to_triangles.push(Default::default());
     vertex_to_triangles
 }
 


### PR DESCRIPTION
A prior hack added to work around empty bindings not working came back to haunt us.

The clean handling is to skip vertex normal computation if all the vertices are open.

Fixes #246 