### PR TITLE
Make No Warning Default

### DIFF
--- a/python/src/squishy_volumes_extension/preferences.py
+++ b/python/src/squishy_volumes_extension/preferences.py
@@ -30,7 +30,7 @@ To prevent accidental deletion a popup adds a manual confirmation step:
 'WARNING: This is a destructive operation!'
 
 Disable this option to skip that popup.""",
-        default=True,
+        default=False,
     )  # type: ignore
 
     domain_min: bpy.props.FloatVectorProperty(


### PR DESCRIPTION
This warning:
<img width="554" height="231" alt="image" src="https://github.com/user-attachments/assets/4a7e094b-facf-4dda-8044-e702dca14f8c" />

Still can be enabled in preferences:
<img width="772" height="257" alt="image" src="https://github.com/user-attachments/assets/85f1162b-e167-4eaa-837a-a43ea6e2fe70" />
