### PR TITLE
Failed State

### DIFF
--- a/python/src/squishy_volumes_extension/example/benchmark.py
+++ b/python/src/squishy_volumes_extension/example/benchmark.py
@@ -172,7 +172,7 @@ def setup_example_benchmark(context: bpy.types.Context):
             grid_collider_bits=False,
             grid_masses=False,
             grid_velocities=False,
-            particle_flags=False,
+            particle_flags=True,
             particle_masses=False,
             particle_initial_volumes=False,
             particle_initial_positions=True,

--- a/python/src/squishy_volumes_extension/example/boing_block.py
+++ b/python/src/squishy_volumes_extension/example/boing_block.py
@@ -118,7 +118,7 @@ def setup_example_boing_block(context: bpy.types.Context):
             grid_collider_bits=False,
             grid_masses=False,
             grid_velocities=False,
-            particle_flags=False,
+            particle_flags=True,
             particle_masses=False,
             particle_initial_volumes=False,
             particle_initial_positions=True,

--- a/python/src/squishy_volumes_extension/nodes/__init__.py
+++ b/python/src/squishy_volumes_extension/nodes/__init__.py
@@ -82,7 +82,7 @@ def create_geometry_nodes_particles() -> bpy.types.NodeTree:
     colored_instances = create_material_colored_instances()
     return _load_tree_clipper_tree(
         "geometry_nodes_particles.json",
-        [(1148, colored_instances)],
+        [(1232, colored_instances)],
     )
 
 

--- a/python/src/squishy_volumes_extension/nodes/geometry_nodes_particles.json
+++ b/python/src/squishy_volumes_extension/nodes/geometry_nodes_particles.json
@@ -1,6 +1,6 @@
 {
     "blender_version": "5.0.1",
-    "tree_clipper_version": "0.1.7",
+    "tree_clipper_version": "0.1.11",
     "node_trees": [
         {
             "id": 0,
@@ -4312,7 +4312,7 @@
                                                         "pin_gizmo": false,
                                                         "type": "MATERIAL",
                                                         "display_shape": "LINE",
-                                                        "default_value": 1148
+                                                        "default_value": 1232
                                                     }
                                                 }
                                             ]
@@ -12912,7 +12912,7 @@
         {
             "id": 851,
             "data": {
-                "name": "Squishy Volumes Particle",
+                "name": "Squishy Volumes Get Flag",
                 "use_fake_user": false,
                 "use_extra_user": true,
                 "is_runtime_data": false,
@@ -12931,6 +12931,862 @@
                                 "items": [
                                     {
                                         "id": 854,
+                                        "data": {
+                                            "name": "Value",
+                                            "description": "",
+                                            "socket_type": "NodeSocketBool",
+                                            "hide_value": false,
+                                            "hide_in_modifier": false,
+                                            "force_non_field": false,
+                                            "is_inspect_output": false,
+                                            "is_panel_toggle": false,
+                                            "layer_selection_field": false,
+                                            "menu_expanded": false,
+                                            "optional_label": false,
+                                            "attribute_domain": "POINT",
+                                            "default_attribute_name": "",
+                                            "structure_type": "AUTO",
+                                            "default_input": "VALUE",
+                                            "in_out": "OUTPUT",
+                                            "item_type": "SOCKET",
+                                            "default_value": false
+                                        }
+                                    },
+                                    {
+                                        "id": 855,
+                                        "data": {
+                                            "name": "Flag",
+                                            "description": "",
+                                            "socket_type": "NodeSocketMenu",
+                                            "hide_value": false,
+                                            "hide_in_modifier": false,
+                                            "force_non_field": false,
+                                            "is_inspect_output": false,
+                                            "is_panel_toggle": false,
+                                            "layer_selection_field": false,
+                                            "menu_expanded": false,
+                                            "optional_label": true,
+                                            "attribute_domain": "POINT",
+                                            "default_attribute_name": "",
+                                            "structure_type": "AUTO",
+                                            "default_input": "VALUE",
+                                            "in_out": "INPUT",
+                                            "item_type": "SOCKET",
+                                            "default_value": "FAILED"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "nodes": {
+                    "id": 856,
+                    "data": {
+                        "active": 857,
+                        "items": [
+                            {
+                                "id": 857,
+                                "data": {
+                                    "location": [
+                                        440.0,
+                                        0.0
+                                    ],
+                                    "location_absolute": [
+                                        440.0,
+                                        0.0
+                                    ],
+                                    "width": 140.0,
+                                    "height": 100.0,
+                                    "name": "Group Output",
+                                    "label": "",
+                                    "warning_propagation": "ALL",
+                                    "use_custom_color": false,
+                                    "color": [
+                                        0.6079999804496765,
+                                        0.6079999804496765,
+                                        0.6079999804496765
+                                    ],
+                                    "select": false,
+                                    "show_options": true,
+                                    "show_preview": false,
+                                    "hide": false,
+                                    "mute": false,
+                                    "show_texture": false,
+                                    "inputs": {
+                                        "id": 858,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 859,
+                                                    "data": {
+                                                        "name": "Value",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": false
+                                                    }
+                                                },
+                                                {
+                                                    "id": 860,
+                                                    "data": {
+                                                        "name": "",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "CUSTOM",
+                                                        "display_shape": "CIRCLE"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "outputs": {
+                                        "id": 861,
+                                        "data": {
+                                            "items": []
+                                        }
+                                    },
+                                    "bl_idname": "NodeGroupOutput",
+                                    "parent": null,
+                                    "is_active_output": true
+                                }
+                            },
+                            {
+                                "id": 862,
+                                "data": {
+                                    "location": [
+                                        -150.0,
+                                        90.0
+                                    ],
+                                    "location_absolute": [
+                                        -150.0,
+                                        90.0
+                                    ],
+                                    "width": 220.0,
+                                    "height": 100.0,
+                                    "name": "Named Attribute.003",
+                                    "label": "",
+                                    "warning_propagation": "ALL",
+                                    "use_custom_color": false,
+                                    "color": [
+                                        0.6079999804496765,
+                                        0.6079999804496765,
+                                        0.6079999804496765
+                                    ],
+                                    "select": false,
+                                    "show_options": true,
+                                    "show_preview": false,
+                                    "hide": false,
+                                    "mute": false,
+                                    "show_texture": false,
+                                    "inputs": {
+                                        "id": 863,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 864,
+                                                    "data": {
+                                                        "name": "Name",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "STRING",
+                                                        "display_shape": "LINE",
+                                                        "default_value": "squishy_volumes_flags"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "outputs": {
+                                        "id": 865,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 866,
+                                                    "data": {
+                                                        "name": "Attribute",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "DIAMOND",
+                                                        "default_value": 0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 867,
+                                                    "data": {
+                                                        "name": "Exists",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "DIAMOND",
+                                                        "default_value": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "bl_idname": "GeometryNodeInputNamedAttribute",
+                                    "parent": null,
+                                    "data_type": "INT"
+                                }
+                            },
+                            {
+                                "id": 868,
+                                "data": {
+                                    "location": [
+                                        150.0,
+                                        30.0
+                                    ],
+                                    "location_absolute": [
+                                        150.0,
+                                        30.0
+                                    ],
+                                    "width": 240.0,
+                                    "height": 100.0,
+                                    "name": "Squishy Volumes Get Bit",
+                                    "label": "",
+                                    "warning_propagation": "ALL",
+                                    "use_custom_color": false,
+                                    "color": [
+                                        0.6079999804496765,
+                                        0.6079999804496765,
+                                        0.6079999804496765
+                                    ],
+                                    "select": false,
+                                    "show_options": true,
+                                    "show_preview": false,
+                                    "hide": false,
+                                    "mute": false,
+                                    "show_texture": false,
+                                    "inputs": {
+                                        "id": 869,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 870,
+                                                    "data": {
+                                                        "name": "Bits",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 871,
+                                                    "data": {
+                                                        "name": "Bit",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "outputs": {
+                                        "id": 872,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 873,
+                                                    "data": {
+                                                        "name": "Value",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "bl_idname": "GeometryNodeGroup",
+                                    "parent": null,
+                                    "node_tree": 137
+                                }
+                            },
+                            {
+                                "id": 874,
+                                "data": {
+                                    "location": [
+                                        -70.0,
+                                        -90.0
+                                    ],
+                                    "location_absolute": [
+                                        -70.0,
+                                        -90.0
+                                    ],
+                                    "width": 140.0,
+                                    "height": 100.0,
+                                    "name": "Menu Switch.001",
+                                    "label": "",
+                                    "warning_propagation": "ALL",
+                                    "use_custom_color": false,
+                                    "color": [
+                                        0.6079999804496765,
+                                        0.6079999804496765,
+                                        0.6079999804496765
+                                    ],
+                                    "select": false,
+                                    "show_options": true,
+                                    "show_preview": false,
+                                    "hide": false,
+                                    "mute": false,
+                                    "show_texture": false,
+                                    "active_index": 6,
+                                    "data_type": "INT",
+                                    "inputs": {
+                                        "id": 875,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 876,
+                                                    "data": {
+                                                        "name": "Menu",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "MENU",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": "FAILED"
+                                                    }
+                                                },
+                                                {
+                                                    "id": 877,
+                                                    "data": {
+                                                        "name": "IS_SOLID",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 878,
+                                                    "data": {
+                                                        "name": "IS_FLUID",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 1
+                                                    }
+                                                },
+                                                {
+                                                    "id": 879,
+                                                    "data": {
+                                                        "name": "USE_VISCOSITY",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 2
+                                                    }
+                                                },
+                                                {
+                                                    "id": 880,
+                                                    "data": {
+                                                        "name": "USE_SAND_ALPHA",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 3
+                                                    }
+                                                },
+                                                {
+                                                    "id": 881,
+                                                    "data": {
+                                                        "name": "HAS_GOAL",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 4
+                                                    }
+                                                },
+                                                {
+                                                    "id": 882,
+                                                    "data": {
+                                                        "name": "TOMBSTONED",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 5
+                                                    }
+                                                },
+                                                {
+                                                    "id": 883,
+                                                    "data": {
+                                                        "name": "FAILED",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 6
+                                                    }
+                                                },
+                                                {
+                                                    "id": 884,
+                                                    "data": {
+                                                        "name": "",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "CUSTOM",
+                                                        "display_shape": "CIRCLE"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "outputs": {
+                                        "id": 885,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 886,
+                                                    "data": {
+                                                        "name": "Output",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 887,
+                                                    "data": {
+                                                        "name": "IS_SOLID",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": false
+                                                    }
+                                                },
+                                                {
+                                                    "id": 888,
+                                                    "data": {
+                                                        "name": "IS_FLUID",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": false
+                                                    }
+                                                },
+                                                {
+                                                    "id": 889,
+                                                    "data": {
+                                                        "name": "USE_VISCOSITY",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": false
+                                                    }
+                                                },
+                                                {
+                                                    "id": 890,
+                                                    "data": {
+                                                        "name": "USE_SAND_ALPHA",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": false
+                                                    }
+                                                },
+                                                {
+                                                    "id": 891,
+                                                    "data": {
+                                                        "name": "HAS_GOAL",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": false
+                                                    }
+                                                },
+                                                {
+                                                    "id": 892,
+                                                    "data": {
+                                                        "name": "TOMBSTONED",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": false
+                                                    }
+                                                },
+                                                {
+                                                    "id": 893,
+                                                    "data": {
+                                                        "name": "FAILED",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "bl_idname": "GeometryNodeMenuSwitch",
+                                    "enum_items": {
+                                        "id": 894,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 895,
+                                                    "data": {
+                                                        "name": "IS_SOLID",
+                                                        "description": ""
+                                                    }
+                                                },
+                                                {
+                                                    "id": 896,
+                                                    "data": {
+                                                        "name": "IS_FLUID",
+                                                        "description": ""
+                                                    }
+                                                },
+                                                {
+                                                    "id": 897,
+                                                    "data": {
+                                                        "name": "USE_VISCOSITY",
+                                                        "description": ""
+                                                    }
+                                                },
+                                                {
+                                                    "id": 898,
+                                                    "data": {
+                                                        "name": "USE_SAND_ALPHA",
+                                                        "description": ""
+                                                    }
+                                                },
+                                                {
+                                                    "id": 899,
+                                                    "data": {
+                                                        "name": "HAS_GOAL",
+                                                        "description": ""
+                                                    }
+                                                },
+                                                {
+                                                    "id": 900,
+                                                    "data": {
+                                                        "name": "TOMBSTONED",
+                                                        "description": ""
+                                                    }
+                                                },
+                                                {
+                                                    "id": 901,
+                                                    "data": {
+                                                        "name": "FAILED",
+                                                        "description": ""
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "parent": null
+                                }
+                            },
+                            {
+                                "id": 902,
+                                "data": {
+                                    "location": [
+                                        -260.0,
+                                        -100.0
+                                    ],
+                                    "location_absolute": [
+                                        -260.0,
+                                        -100.0
+                                    ],
+                                    "width": 140.0,
+                                    "height": 100.0,
+                                    "name": "Group Input",
+                                    "label": "",
+                                    "warning_propagation": "ALL",
+                                    "use_custom_color": false,
+                                    "color": [
+                                        0.6079999804496765,
+                                        0.6079999804496765,
+                                        0.6079999804496765
+                                    ],
+                                    "select": false,
+                                    "show_options": true,
+                                    "show_preview": false,
+                                    "hide": false,
+                                    "mute": false,
+                                    "show_texture": false,
+                                    "inputs": {
+                                        "id": 903,
+                                        "data": {
+                                            "items": []
+                                        }
+                                    },
+                                    "outputs": {
+                                        "id": 904,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 905,
+                                                    "data": {
+                                                        "name": "Flag",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "MENU",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": "FAILED"
+                                                    }
+                                                },
+                                                {
+                                                    "id": 906,
+                                                    "data": {
+                                                        "name": "",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "CUSTOM",
+                                                        "display_shape": "CIRCLE"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "bl_idname": "NodeGroupInput",
+                                    "parent": null
+                                }
+                            }
+                        ]
+                    }
+                },
+                "bl_idname": "GeometryNodeTree",
+                "annotation": null,
+                "links": {
+                    "id": 907,
+                    "data": {
+                        "items": [
+                            {
+                                "id": 908,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 866,
+                                    "to_socket": 870
+                                }
+                            },
+                            {
+                                "id": 909,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 886,
+                                    "to_socket": 871
+                                }
+                            },
+                            {
+                                "id": 910,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 873,
+                                    "to_socket": 859
+                                }
+                            },
+                            {
+                                "id": 911,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 905,
+                                    "to_socket": 876
+                                }
+                            }
+                        ]
+                    }
+                },
+                "is_tool": false,
+                "is_modifier": false,
+                "is_mode_object": false,
+                "is_mode_edit": false,
+                "is_mode_sculpt": false,
+                "is_mode_paint": false,
+                "is_type_mesh": false,
+                "is_type_curve": false,
+                "is_type_pointcloud": false,
+                "use_wait_for_click": false,
+                "is_type_grease_pencil": false,
+                "show_modifier_manage_panel": true
+            }
+        },
+        {
+            "id": 912,
+            "data": {
+                "name": "Squishy Volumes Particle",
+                "use_fake_user": false,
+                "use_extra_user": true,
+                "is_runtime_data": false,
+                "tag": false,
+                "color_tag": "NONE",
+                "default_group_node_width": 140,
+                "description": "",
+                "bl_use_group_interface": true,
+                "interface": {
+                    "id": 913,
+                    "data": {
+                        "active_index": 3,
+                        "items_tree": {
+                            "id": 914,
+                            "data": {
+                                "items": [
+                                    {
+                                        "id": 915,
                                         "data": {
                                             "name": "Geometry",
                                             "description": "",
@@ -12952,7 +13808,7 @@
                                         }
                                     },
                                     {
-                                        "id": 855,
+                                        "id": 916,
                                         "data": {
                                             "name": "Geometry",
                                             "description": "",
@@ -12974,7 +13830,7 @@
                                         }
                                     },
                                     {
-                                        "id": 856,
+                                        "id": 917,
                                         "data": {
                                             "name": "Grid Node Size",
                                             "description": "",
@@ -13000,7 +13856,7 @@
                                         }
                                     },
                                     {
-                                        "id": 857,
+                                        "id": 918,
                                         "data": {
                                             "name": "Display as",
                                             "description": "",
@@ -13023,7 +13879,7 @@
                                         }
                                     },
                                     {
-                                        "id": 858,
+                                        "id": 919,
                                         "data": {
                                             "name": "Coloring",
                                             "description": "",
@@ -13046,7 +13902,7 @@
                                         }
                                     },
                                     {
-                                        "id": 859,
+                                        "id": 920,
                                         "data": {
                                             "name": "Divide by 10^x",
                                             "description": "",
@@ -13072,7 +13928,7 @@
                                         }
                                     },
                                     {
-                                        "id": 860,
+                                        "id": 921,
                                         "data": {
                                             "name": "Collider Idx",
                                             "description": "",
@@ -13098,7 +13954,7 @@
                                         }
                                     },
                                     {
-                                        "id": 861,
+                                        "id": 922,
                                         "data": {
                                             "name": "Scale",
                                             "description": "",
@@ -13124,7 +13980,7 @@
                                         }
                                     },
                                     {
-                                        "id": 862,
+                                        "id": 923,
                                         "data": {
                                             "name": "Threshold",
                                             "description": "",
@@ -13150,7 +14006,7 @@
                                         }
                                     },
                                     {
-                                        "id": 863,
+                                        "id": 924,
                                         "data": {
                                             "name": "Material",
                                             "description": "",
@@ -13173,7 +14029,7 @@
                                         }
                                     },
                                     {
-                                        "id": 864,
+                                        "id": 925,
                                         "data": {
                                             "name": "Shade Smooth",
                                             "description": "",
@@ -13196,7 +14052,7 @@
                                         }
                                     },
                                     {
-                                        "id": 865,
+                                        "id": 926,
                                         "data": {
                                             "name": "Blur Iterations",
                                             "description": "How many times to blur the values for all elements",
@@ -13222,7 +14078,7 @@
                                         }
                                     },
                                     {
-                                        "id": 866,
+                                        "id": 927,
                                         "data": {
                                             "name": "Input Object",
                                             "description": "",
@@ -13245,7 +14101,7 @@
                                         }
                                     },
                                     {
-                                        "id": 867,
+                                        "id": 928,
                                         "data": {
                                             "name": "Skin",
                                             "description": "",
@@ -13268,7 +14124,33 @@
                                         }
                                     },
                                     {
-                                        "id": 868,
+                                        "id": 929,
+                                        "data": {
+                                            "name": "Failed Scale",
+                                            "description": "How much larger failed particles are scaled.",
+                                            "socket_type": "NodeSocketFloat",
+                                            "hide_value": false,
+                                            "hide_in_modifier": false,
+                                            "force_non_field": false,
+                                            "is_inspect_output": false,
+                                            "is_panel_toggle": false,
+                                            "layer_selection_field": false,
+                                            "menu_expanded": false,
+                                            "optional_label": false,
+                                            "attribute_domain": "POINT",
+                                            "default_attribute_name": "",
+                                            "structure_type": "AUTO",
+                                            "default_input": "VALUE",
+                                            "in_out": "INPUT",
+                                            "item_type": "SOCKET",
+                                            "subtype": "NONE",
+                                            "default_value": 5.0,
+                                            "min_value": 0.0,
+                                            "max_value": 10000.0
+                                        }
+                                    },
+                                    {
+                                        "id": 930,
                                         "data": {
                                             "name": "Velocity",
                                             "description": "",
@@ -13277,7 +14159,7 @@
                                         }
                                     },
                                     {
-                                        "id": 869,
+                                        "id": 931,
                                         "data": {
                                             "name": "Velocity",
                                             "description": "",
@@ -13296,12 +14178,12 @@
                                             "default_input": "VALUE",
                                             "in_out": "INPUT",
                                             "item_type": "SOCKET",
-                                            "parent_index": 14,
+                                            "parent_index": 15,
                                             "default_value": false
                                         }
                                     },
                                     {
-                                        "id": 870,
+                                        "id": 932,
                                         "data": {
                                             "name": "Velocity Scale",
                                             "description": "",
@@ -13320,7 +14202,7 @@
                                             "default_input": "VALUE",
                                             "in_out": "INPUT",
                                             "item_type": "SOCKET",
-                                            "parent_index": 14,
+                                            "parent_index": 15,
                                             "subtype": "NONE",
                                             "default_value": 1.0,
                                             "min_value": 0.0,
@@ -13333,12 +14215,12 @@
                     }
                 },
                 "nodes": {
-                    "id": 871,
+                    "id": 933,
                     "data": {
-                        "active": 897,
+                        "active": 1182,
                         "items": [
                             {
-                                "id": 872,
+                                "id": 934,
                                 "data": {
                                     "location": [
                                         380.0,
@@ -13366,17 +14248,17 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 873,
+                                        "id": 935,
                                         "data": {
                                             "items": []
                                         }
                                     },
                                     "outputs": {
-                                        "id": 874,
+                                        "id": 936,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 875,
+                                                    "id": 937,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -13391,7 +14273,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 876,
+                                                    "id": 938,
                                                     "data": {
                                                         "name": "Grid Node Size",
                                                         "description": "",
@@ -13407,7 +14289,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 877,
+                                                    "id": 939,
                                                     "data": {
                                                         "name": "Display as",
                                                         "description": "",
@@ -13422,7 +14304,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 878,
+                                                    "id": 940,
                                                     "data": {
                                                         "name": "Coloring",
                                                         "description": "",
@@ -13437,7 +14319,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 879,
+                                                    "id": 941,
                                                     "data": {
                                                         "name": "Divide by 10^x",
                                                         "description": "",
@@ -13453,7 +14335,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 880,
+                                                    "id": 942,
                                                     "data": {
                                                         "name": "Collider Idx",
                                                         "description": "",
@@ -13469,7 +14351,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 881,
+                                                    "id": 943,
                                                     "data": {
                                                         "name": "Scale",
                                                         "description": "",
@@ -13485,7 +14367,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 882,
+                                                    "id": 944,
                                                     "data": {
                                                         "name": "Threshold",
                                                         "description": "",
@@ -13501,7 +14383,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 883,
+                                                    "id": 945,
                                                     "data": {
                                                         "name": "Material",
                                                         "description": "",
@@ -13517,7 +14399,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 884,
+                                                    "id": 946,
                                                     "data": {
                                                         "name": "Shade Smooth",
                                                         "description": "",
@@ -13533,7 +14415,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 885,
+                                                    "id": 947,
                                                     "data": {
                                                         "name": "Blur Iterations",
                                                         "description": "",
@@ -13549,7 +14431,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 886,
+                                                    "id": 948,
                                                     "data": {
                                                         "name": "Input Object",
                                                         "description": "",
@@ -13565,7 +14447,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 887,
+                                                    "id": 949,
                                                     "data": {
                                                         "name": "Skin",
                                                         "description": "",
@@ -13581,7 +14463,23 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 888,
+                                                    "id": 950,
+                                                    "data": {
+                                                        "name": "Failed Scale",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0.5
+                                                    }
+                                                },
+                                                {
+                                                    "id": 951,
                                                     "data": {
                                                         "name": "Velocity",
                                                         "description": "",
@@ -13597,7 +14495,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 889,
+                                                    "id": 952,
                                                     "data": {
                                                         "name": "Velocity Scale",
                                                         "description": "",
@@ -13613,7 +14511,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 890,
+                                                    "id": 953,
                                                     "data": {
                                                         "name": "",
                                                         "description": "",
@@ -13635,7 +14533,7 @@
                                 }
                             },
                             {
-                                "id": 891,
+                                "id": 954,
                                 "data": {
                                     "location": [
                                         180.0,
@@ -13663,11 +14561,11 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 892,
+                                        "id": 955,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 893,
+                                                    "id": 956,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -13682,7 +14580,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 894,
+                                                    "id": 957,
                                                     "data": {
                                                         "name": "Scale",
                                                         "description": "",
@@ -13701,11 +14599,11 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 895,
+                                        "id": 958,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 896,
+                                                    "id": 959,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -13728,7 +14626,7 @@
                                 }
                             },
                             {
-                                "id": 897,
+                                "id": 960,
                                 "data": {
                                     "location": [
                                         600.0,
@@ -13756,11 +14654,11 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 898,
+                                        "id": 961,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 899,
+                                                    "id": 962,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -13775,7 +14673,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 900,
+                                                    "id": 963,
                                                     "data": {
                                                         "name": "Coloring",
                                                         "description": "",
@@ -13790,7 +14688,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 901,
+                                                    "id": 964,
                                                     "data": {
                                                         "name": "Divide by 10^x",
                                                         "description": "",
@@ -13806,7 +14704,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 902,
+                                                    "id": 965,
                                                     "data": {
                                                         "name": "Collider Idx",
                                                         "description": "",
@@ -13825,11 +14723,11 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 903,
+                                        "id": 966,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 904,
+                                                    "id": 967,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -13852,7 +14750,7 @@
                                 }
                             },
                             {
-                                "id": 905,
+                                "id": 968,
                                 "data": {
                                     "location": [
                                         280.0,
@@ -13880,11 +14778,11 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 906,
+                                        "id": 969,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 907,
+                                                    "id": 970,
                                                     "data": {
                                                         "name": "Name",
                                                         "description": "",
@@ -13903,11 +14801,11 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 908,
+                                        "id": 971,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 909,
+                                                    "id": 972,
                                                     "data": {
                                                         "name": "Attribute",
                                                         "description": "",
@@ -13927,7 +14825,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 910,
+                                                    "id": 973,
                                                     "data": {
                                                         "name": "Exists",
                                                         "description": "",
@@ -13951,7 +14849,7 @@
                                 }
                             },
                             {
-                                "id": 911,
+                                "id": 974,
                                 "data": {
                                     "location": [
                                         600.0,
@@ -13979,11 +14877,11 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 912,
+                                        "id": 975,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 913,
+                                                    "id": 976,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -13998,7 +14896,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 914,
+                                                    "id": 977,
                                                     "data": {
                                                         "name": "Scale",
                                                         "description": "",
@@ -14014,7 +14912,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 915,
+                                                    "id": 978,
                                                     "data": {
                                                         "name": "Vector",
                                                         "description": "",
@@ -14037,11 +14935,11 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 916,
+                                        "id": 979,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 917,
+                                                    "id": 980,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -14064,7 +14962,7 @@
                                 }
                             },
                             {
-                                "id": 918,
+                                "id": 981,
                                 "data": {
                                     "location": [
                                         1360.0,
@@ -14092,11 +14990,11 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 919,
+                                        "id": 982,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 920,
+                                                    "id": 983,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -14111,7 +15009,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 921,
+                                                    "id": 984,
                                                     "data": {
                                                         "name": "Grid Node Size",
                                                         "description": "",
@@ -14127,7 +15025,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 922,
+                                                    "id": 985,
                                                     "data": {
                                                         "name": "Threshold",
                                                         "description": "",
@@ -14143,7 +15041,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 923,
+                                                    "id": 986,
                                                     "data": {
                                                         "name": "Material",
                                                         "description": "",
@@ -14159,7 +15057,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 924,
+                                                    "id": 987,
                                                     "data": {
                                                         "name": "Shade Smooth",
                                                         "description": "",
@@ -14175,7 +15073,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 925,
+                                                    "id": 988,
                                                     "data": {
                                                         "name": "Iterations",
                                                         "description": "",
@@ -14194,11 +15092,11 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 926,
+                                        "id": 989,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 927,
+                                                    "id": 990,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -14221,7 +15119,7 @@
                                 }
                             },
                             {
-                                "id": 928,
+                                "id": 991,
                                 "data": {
                                     "location": [
                                         960.0,
@@ -14249,11 +15147,11 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 929,
+                                        "id": 992,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 930,
+                                                    "id": 993,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -14271,11 +15169,11 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 931,
+                                        "id": 994,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 932,
+                                                    "id": 995,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -14297,7 +15195,7 @@
                                 }
                             },
                             {
-                                "id": 933,
+                                "id": 996,
                                 "data": {
                                     "location": [
                                         1820.0,
@@ -14324,14 +15222,14 @@
                                     "hide": false,
                                     "mute": false,
                                     "show_texture": false,
-                                    "active_index": 0,
+                                    "active_index": 3,
                                     "data_type": "GEOMETRY",
                                     "inputs": {
-                                        "id": 934,
+                                        "id": 997,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 935,
+                                                    "id": 998,
                                                     "data": {
                                                         "name": "Menu",
                                                         "description": "",
@@ -14346,7 +15244,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 936,
+                                                    "id": 999,
                                                     "data": {
                                                         "name": "Points",
                                                         "description": "",
@@ -14361,7 +15259,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 937,
+                                                    "id": 1000,
                                                     "data": {
                                                         "name": "Deformed Cubes",
                                                         "description": "",
@@ -14376,7 +15274,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 938,
+                                                    "id": 1001,
                                                     "data": {
                                                         "name": "Reconstructed",
                                                         "description": "",
@@ -14391,7 +15289,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 939,
+                                                    "id": 1002,
                                                     "data": {
                                                         "name": "Skin",
                                                         "description": "",
@@ -14406,7 +15304,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 940,
+                                                    "id": 1003,
                                                     "data": {
                                                         "name": "",
                                                         "description": "",
@@ -14424,11 +15322,11 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 941,
+                                        "id": 1004,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 942,
+                                                    "id": 1005,
                                                     "data": {
                                                         "name": "Output",
                                                         "description": "",
@@ -14443,7 +15341,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 943,
+                                                    "id": 1006,
                                                     "data": {
                                                         "name": "Points",
                                                         "description": "",
@@ -14459,7 +15357,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 944,
+                                                    "id": 1007,
                                                     "data": {
                                                         "name": "Deformed Cubes",
                                                         "description": "",
@@ -14475,7 +15373,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 945,
+                                                    "id": 1008,
                                                     "data": {
                                                         "name": "Reconstructed",
                                                         "description": "",
@@ -14491,7 +15389,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 946,
+                                                    "id": 1009,
                                                     "data": {
                                                         "name": "Skin",
                                                         "description": "",
@@ -14511,32 +15409,32 @@
                                     },
                                     "bl_idname": "GeometryNodeMenuSwitch",
                                     "enum_items": {
-                                        "id": 947,
+                                        "id": 1010,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 948,
+                                                    "id": 1011,
                                                     "data": {
                                                         "name": "Points",
                                                         "description": ""
                                                     }
                                                 },
                                                 {
-                                                    "id": 949,
+                                                    "id": 1012,
                                                     "data": {
                                                         "name": "Deformed Cubes",
                                                         "description": ""
                                                     }
                                                 },
                                                 {
-                                                    "id": 950,
+                                                    "id": 1013,
                                                     "data": {
                                                         "name": "Reconstructed",
                                                         "description": ""
                                                     }
                                                 },
                                                 {
-                                                    "id": 951,
+                                                    "id": 1014,
                                                     "data": {
                                                         "name": "Skin",
                                                         "description": ""
@@ -14549,7 +15447,7 @@
                                 }
                             },
                             {
-                                "id": 952,
+                                "id": 1015,
                                 "data": {
                                     "location": [
                                         2020.0,
@@ -14577,11 +15475,11 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 953,
+                                        "id": 1016,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 954,
+                                                    "id": 1017,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -14596,7 +15494,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 955,
+                                                    "id": 1018,
                                                     "data": {
                                                         "name": "",
                                                         "description": "",
@@ -14614,7 +15512,7 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 956,
+                                        "id": 1019,
                                         "data": {
                                             "items": []
                                         }
@@ -14625,7 +15523,7 @@
                                 }
                             },
                             {
-                                "id": 957,
+                                "id": 1020,
                                 "data": {
                                     "location": [
                                         -80.0,
@@ -14653,1018 +15551,34 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 958,
+                                        "id": 1021,
                                         "data": {
                                             "items": []
                                         }
                                     },
                                     "outputs": {
-                                        "id": 959,
-                                        "data": {
-                                            "items": [
-                                                {
-                                                    "id": 960,
-                                                    "data": {
-                                                        "name": "Geometry",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "GEOMETRY",
-                                                        "display_shape": "LINE"
-                                                    }
-                                                },
-                                                {
-                                                    "id": 961,
-                                                    "data": {
-                                                        "name": "Grid Node Size",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 0.25
-                                                    }
-                                                },
-                                                {
-                                                    "id": 962,
-                                                    "data": {
-                                                        "name": "Display as",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "MENU",
-                                                        "display_shape": "LINE"
-                                                    }
-                                                },
-                                                {
-                                                    "id": 963,
-                                                    "data": {
-                                                        "name": "Coloring",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "MENU",
-                                                        "display_shape": "CIRCLE"
-                                                    }
-                                                },
-                                                {
-                                                    "id": 964,
-                                                    "data": {
-                                                        "name": "Divide by 10^x",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "CIRCLE",
-                                                        "default_value": 3.0
-                                                    }
-                                                },
-                                                {
-                                                    "id": 965,
-                                                    "data": {
-                                                        "name": "Collider Idx",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "INT",
-                                                        "display_shape": "CIRCLE",
-                                                        "default_value": 0
-                                                    }
-                                                },
-                                                {
-                                                    "id": 966,
-                                                    "data": {
-                                                        "name": "Scale",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 1.0
-                                                    }
-                                                },
-                                                {
-                                                    "id": 967,
-                                                    "data": {
-                                                        "name": "Threshold",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 0.5
-                                                    }
-                                                },
-                                                {
-                                                    "id": 968,
-                                                    "data": {
-                                                        "name": "Material",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "MATERIAL",
-                                                        "display_shape": "LINE",
-                                                        "default_value": null
-                                                    }
-                                                },
-                                                {
-                                                    "id": 969,
-                                                    "data": {
-                                                        "name": "Shade Smooth",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "BOOLEAN",
-                                                        "display_shape": "DIAMOND",
-                                                        "default_value": true
-                                                    }
-                                                },
-                                                {
-                                                    "id": 970,
-                                                    "data": {
-                                                        "name": "Blur Iterations",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "INT",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 1
-                                                    }
-                                                },
-                                                {
-                                                    "id": 971,
-                                                    "data": {
-                                                        "name": "Input Object",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "OBJECT",
-                                                        "display_shape": "LINE",
-                                                        "default_value": null
-                                                    }
-                                                },
-                                                {
-                                                    "id": 972,
-                                                    "data": {
-                                                        "name": "Skin",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "OBJECT",
-                                                        "display_shape": "LINE",
-                                                        "default_value": null
-                                                    }
-                                                },
-                                                {
-                                                    "id": 973,
-                                                    "data": {
-                                                        "name": "Velocity",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "BOOLEAN",
-                                                        "display_shape": "LINE",
-                                                        "default_value": false
-                                                    }
-                                                },
-                                                {
-                                                    "id": 974,
-                                                    "data": {
-                                                        "name": "Velocity Scale",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "CIRCLE",
-                                                        "default_value": 1.0
-                                                    }
-                                                },
-                                                {
-                                                    "id": 975,
-                                                    "data": {
-                                                        "name": "",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "CUSTOM",
-                                                        "display_shape": "CIRCLE"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    "bl_idname": "NodeGroupInput",
-                                    "parent": null
-                                }
-                            },
-                            {
-                                "id": 976,
-                                "data": {
-                                    "location": [
-                                        1160.0,
-                                        -460.0
-                                    ],
-                                    "location_absolute": [
-                                        1160.0,
-                                        -460.0
-                                    ],
-                                    "width": 140.0,
-                                    "height": 100.0,
-                                    "name": "Group Input.002",
-                                    "label": "",
-                                    "warning_propagation": "ALL",
-                                    "use_custom_color": false,
-                                    "color": [
-                                        0.6079999804496765,
-                                        0.6079999804496765,
-                                        0.6079999804496765
-                                    ],
-                                    "select": false,
-                                    "show_options": true,
-                                    "show_preview": false,
-                                    "hide": false,
-                                    "mute": false,
-                                    "show_texture": false,
-                                    "inputs": {
-                                        "id": 977,
-                                        "data": {
-                                            "items": []
-                                        }
-                                    },
-                                    "outputs": {
-                                        "id": 978,
-                                        "data": {
-                                            "items": [
-                                                {
-                                                    "id": 979,
-                                                    "data": {
-                                                        "name": "Geometry",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "GEOMETRY",
-                                                        "display_shape": "LINE"
-                                                    }
-                                                },
-                                                {
-                                                    "id": 980,
-                                                    "data": {
-                                                        "name": "Grid Node Size",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 0.25
-                                                    }
-                                                },
-                                                {
-                                                    "id": 981,
-                                                    "data": {
-                                                        "name": "Display as",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "MENU",
-                                                        "display_shape": "LINE"
-                                                    }
-                                                },
-                                                {
-                                                    "id": 982,
-                                                    "data": {
-                                                        "name": "Coloring",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "MENU",
-                                                        "display_shape": "CIRCLE"
-                                                    }
-                                                },
-                                                {
-                                                    "id": 983,
-                                                    "data": {
-                                                        "name": "Divide by 10^x",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "CIRCLE",
-                                                        "default_value": 3.0
-                                                    }
-                                                },
-                                                {
-                                                    "id": 984,
-                                                    "data": {
-                                                        "name": "Collider Idx",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "INT",
-                                                        "display_shape": "CIRCLE",
-                                                        "default_value": 0
-                                                    }
-                                                },
-                                                {
-                                                    "id": 985,
-                                                    "data": {
-                                                        "name": "Scale",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 1.0
-                                                    }
-                                                },
-                                                {
-                                                    "id": 986,
-                                                    "data": {
-                                                        "name": "Threshold",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 0.5
-                                                    }
-                                                },
-                                                {
-                                                    "id": 987,
-                                                    "data": {
-                                                        "name": "Material",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "MATERIAL",
-                                                        "display_shape": "LINE",
-                                                        "default_value": null
-                                                    }
-                                                },
-                                                {
-                                                    "id": 988,
-                                                    "data": {
-                                                        "name": "Shade Smooth",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "BOOLEAN",
-                                                        "display_shape": "DIAMOND",
-                                                        "default_value": true
-                                                    }
-                                                },
-                                                {
-                                                    "id": 989,
-                                                    "data": {
-                                                        "name": "Blur Iterations",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "INT",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 1
-                                                    }
-                                                },
-                                                {
-                                                    "id": 990,
-                                                    "data": {
-                                                        "name": "Input Object",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "OBJECT",
-                                                        "display_shape": "LINE",
-                                                        "default_value": null
-                                                    }
-                                                },
-                                                {
-                                                    "id": 991,
-                                                    "data": {
-                                                        "name": "Skin",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "OBJECT",
-                                                        "display_shape": "LINE",
-                                                        "default_value": null
-                                                    }
-                                                },
-                                                {
-                                                    "id": 992,
-                                                    "data": {
-                                                        "name": "Velocity",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "BOOLEAN",
-                                                        "display_shape": "LINE",
-                                                        "default_value": false
-                                                    }
-                                                },
-                                                {
-                                                    "id": 993,
-                                                    "data": {
-                                                        "name": "Velocity Scale",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "CIRCLE",
-                                                        "default_value": 1.0
-                                                    }
-                                                },
-                                                {
-                                                    "id": 994,
-                                                    "data": {
-                                                        "name": "",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "CUSTOM",
-                                                        "display_shape": "CIRCLE"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    "bl_idname": "NodeGroupInput",
-                                    "parent": null
-                                }
-                            },
-                            {
-                                "id": 995,
-                                "data": {
-                                    "location": [
-                                        960.0,
-                                        -80.0
-                                    ],
-                                    "location_absolute": [
-                                        960.0,
-                                        -80.0
-                                    ],
-                                    "width": 140.0,
-                                    "height": 100.0,
-                                    "name": "Group Input.003",
-                                    "label": "",
-                                    "warning_propagation": "ALL",
-                                    "use_custom_color": false,
-                                    "color": [
-                                        0.6079999804496765,
-                                        0.6079999804496765,
-                                        0.6079999804496765
-                                    ],
-                                    "select": false,
-                                    "show_options": true,
-                                    "show_preview": false,
-                                    "hide": false,
-                                    "mute": false,
-                                    "show_texture": false,
-                                    "inputs": {
-                                        "id": 996,
-                                        "data": {
-                                            "items": []
-                                        }
-                                    },
-                                    "outputs": {
-                                        "id": 997,
-                                        "data": {
-                                            "items": [
-                                                {
-                                                    "id": 998,
-                                                    "data": {
-                                                        "name": "Geometry",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "GEOMETRY",
-                                                        "display_shape": "LINE"
-                                                    }
-                                                },
-                                                {
-                                                    "id": 999,
-                                                    "data": {
-                                                        "name": "Grid Node Size",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 0.25
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1000,
-                                                    "data": {
-                                                        "name": "Display as",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "MENU",
-                                                        "display_shape": "LINE"
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1001,
-                                                    "data": {
-                                                        "name": "Coloring",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "MENU",
-                                                        "display_shape": "CIRCLE"
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1002,
-                                                    "data": {
-                                                        "name": "Divide by 10^x",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "CIRCLE",
-                                                        "default_value": 3.0
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1003,
-                                                    "data": {
-                                                        "name": "Collider Idx",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "INT",
-                                                        "display_shape": "CIRCLE",
-                                                        "default_value": 0
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1004,
-                                                    "data": {
-                                                        "name": "Scale",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 1.0
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1005,
-                                                    "data": {
-                                                        "name": "Threshold",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 0.5
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1006,
-                                                    "data": {
-                                                        "name": "Material",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "MATERIAL",
-                                                        "display_shape": "LINE",
-                                                        "default_value": null
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1007,
-                                                    "data": {
-                                                        "name": "Shade Smooth",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "BOOLEAN",
-                                                        "display_shape": "DIAMOND",
-                                                        "default_value": true
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1008,
-                                                    "data": {
-                                                        "name": "Blur Iterations",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "INT",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 1
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1009,
-                                                    "data": {
-                                                        "name": "Input Object",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "OBJECT",
-                                                        "display_shape": "LINE",
-                                                        "default_value": null
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1010,
-                                                    "data": {
-                                                        "name": "Skin",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "OBJECT",
-                                                        "display_shape": "LINE",
-                                                        "default_value": null
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1011,
-                                                    "data": {
-                                                        "name": "Velocity",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "BOOLEAN",
-                                                        "display_shape": "LINE",
-                                                        "default_value": false
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1012,
-                                                    "data": {
-                                                        "name": "Velocity Scale",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "CIRCLE",
-                                                        "default_value": 1.0
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1013,
-                                                    "data": {
-                                                        "name": "",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "CUSTOM",
-                                                        "display_shape": "CIRCLE"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    "bl_idname": "NodeGroupInput",
-                                    "parent": null
-                                }
-                            },
-                            {
-                                "id": 1014,
-                                "data": {
-                                    "location": [
-                                        1200.0,
-                                        -180.0
-                                    ],
-                                    "location_absolute": [
-                                        1200.0,
-                                        -180.0
-                                    ],
-                                    "width": 140.0,
-                                    "height": 100.0,
-                                    "name": "Switch",
-                                    "label": "",
-                                    "warning_propagation": "ALL",
-                                    "use_custom_color": false,
-                                    "color": [
-                                        0.6079999804496765,
-                                        0.6079999804496765,
-                                        0.6079999804496765
-                                    ],
-                                    "select": false,
-                                    "show_options": true,
-                                    "show_preview": false,
-                                    "hide": false,
-                                    "mute": false,
-                                    "show_texture": false,
-                                    "inputs": {
-                                        "id": 1015,
-                                        "data": {
-                                            "items": [
-                                                {
-                                                    "id": 1016,
-                                                    "data": {
-                                                        "name": "Switch",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 1,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "BOOLEAN",
-                                                        "display_shape": "LINE",
-                                                        "default_value": false
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1017,
-                                                    "data": {
-                                                        "name": "False",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 1,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "GEOMETRY",
-                                                        "display_shape": "LINE"
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1018,
-                                                    "data": {
-                                                        "name": "True",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 1,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "GEOMETRY",
-                                                        "display_shape": "LINE"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    "outputs": {
-                                        "id": 1019,
-                                        "data": {
-                                            "items": [
-                                                {
-                                                    "id": 1020,
-                                                    "data": {
-                                                        "name": "Output",
-                                                        "description": "",
-                                                        "hide": false,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "GEOMETRY",
-                                                        "display_shape": "LINE"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    "bl_idname": "GeometryNodeSwitch",
-                                    "parent": null,
-                                    "input_type": "GEOMETRY"
-                                }
-                            },
-                            {
-                                "id": 1021,
-                                "data": {
-                                    "location": [
-                                        1400.0,
-                                        520.0
-                                    ],
-                                    "location_absolute": [
-                                        1400.0,
-                                        520.0
-                                    ],
-                                    "width": 140.0,
-                                    "height": 100.0,
-                                    "name": "Group Input.004",
-                                    "label": "",
-                                    "warning_propagation": "ALL",
-                                    "use_custom_color": false,
-                                    "color": [
-                                        0.6079999804496765,
-                                        0.6079999804496765,
-                                        0.6079999804496765
-                                    ],
-                                    "select": false,
-                                    "show_options": true,
-                                    "show_preview": false,
-                                    "hide": false,
-                                    "mute": false,
-                                    "show_texture": false,
-                                    "inputs": {
                                         "id": 1022,
                                         "data": {
-                                            "items": []
-                                        }
-                                    },
-                                    "outputs": {
-                                        "id": 1023,
-                                        "data": {
                                             "items": [
+                                                {
+                                                    "id": 1023,
+                                                    "data": {
+                                                        "name": "Geometry",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "GEOMETRY",
+                                                        "display_shape": "LINE"
+                                                    }
+                                                },
                                                 {
                                                     "id": 1024,
                                                     "data": {
-                                                        "name": "Geometry",
+                                                        "name": "Grid Node Size",
                                                         "description": "",
                                                         "hide": true,
                                                         "enabled": true,
@@ -15672,32 +15586,17 @@
                                                         "show_expanded": false,
                                                         "hide_value": false,
                                                         "pin_gizmo": false,
-                                                        "type": "GEOMETRY",
-                                                        "display_shape": "LINE"
+                                                        "type": "VALUE",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 0.25
                                                     }
                                                 },
                                                 {
                                                     "id": 1025,
                                                     "data": {
-                                                        "name": "Grid Node Size",
-                                                        "description": "",
-                                                        "hide": true,
-                                                        "enabled": true,
-                                                        "link_limit": 4095,
-                                                        "show_expanded": false,
-                                                        "hide_value": false,
-                                                        "pin_gizmo": false,
-                                                        "type": "VALUE",
-                                                        "display_shape": "LINE",
-                                                        "default_value": 0.25
-                                                    }
-                                                },
-                                                {
-                                                    "id": 1026,
-                                                    "data": {
                                                         "name": "Display as",
                                                         "description": "",
-                                                        "hide": false,
+                                                        "hide": true,
                                                         "enabled": true,
                                                         "link_limit": 4095,
                                                         "show_expanded": false,
@@ -15708,11 +15607,11 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1027,
+                                                    "id": 1026,
                                                     "data": {
                                                         "name": "Coloring",
                                                         "description": "",
-                                                        "hide": true,
+                                                        "hide": false,
                                                         "enabled": true,
                                                         "link_limit": 4095,
                                                         "show_expanded": false,
@@ -15723,11 +15622,11 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1028,
+                                                    "id": 1027,
                                                     "data": {
                                                         "name": "Divide by 10^x",
                                                         "description": "",
-                                                        "hide": true,
+                                                        "hide": false,
                                                         "enabled": true,
                                                         "link_limit": 4095,
                                                         "show_expanded": false,
@@ -15739,11 +15638,11 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1029,
+                                                    "id": 1028,
                                                     "data": {
                                                         "name": "Collider Idx",
                                                         "description": "",
-                                                        "hide": true,
+                                                        "hide": false,
                                                         "enabled": true,
                                                         "link_limit": 4095,
                                                         "show_expanded": false,
@@ -15755,11 +15654,11 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1030,
+                                                    "id": 1029,
                                                     "data": {
                                                         "name": "Scale",
                                                         "description": "",
-                                                        "hide": true,
+                                                        "hide": false,
                                                         "enabled": true,
                                                         "link_limit": 4095,
                                                         "show_expanded": false,
@@ -15771,7 +15670,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1031,
+                                                    "id": 1030,
                                                     "data": {
                                                         "name": "Threshold",
                                                         "description": "",
@@ -15787,7 +15686,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1032,
+                                                    "id": 1031,
                                                     "data": {
                                                         "name": "Material",
                                                         "description": "",
@@ -15803,7 +15702,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1033,
+                                                    "id": 1032,
                                                     "data": {
                                                         "name": "Shade Smooth",
                                                         "description": "",
@@ -15819,7 +15718,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1034,
+                                                    "id": 1033,
                                                     "data": {
                                                         "name": "Blur Iterations",
                                                         "description": "",
@@ -15835,9 +15734,25 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1035,
+                                                    "id": 1034,
                                                     "data": {
                                                         "name": "Input Object",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "OBJECT",
+                                                        "display_shape": "LINE",
+                                                        "default_value": null
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1035,
+                                                    "data": {
+                                                        "name": "Skin",
                                                         "description": "",
                                                         "hide": true,
                                                         "enabled": true,
@@ -15853,7 +15768,7 @@
                                                 {
                                                     "id": 1036,
                                                     "data": {
-                                                        "name": "Skin",
+                                                        "name": "Failed Scale",
                                                         "description": "",
                                                         "hide": true,
                                                         "enabled": true,
@@ -15861,9 +15776,9 @@
                                                         "show_expanded": false,
                                                         "hide_value": false,
                                                         "pin_gizmo": false,
-                                                        "type": "OBJECT",
-                                                        "display_shape": "LINE",
-                                                        "default_value": null
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0.5
                                                     }
                                                 },
                                                 {
@@ -15924,6 +15839,1053 @@
                                 "id": 1040,
                                 "data": {
                                     "location": [
+                                        1160.0,
+                                        -460.0
+                                    ],
+                                    "location_absolute": [
+                                        1160.0,
+                                        -460.0
+                                    ],
+                                    "width": 140.0,
+                                    "height": 100.0,
+                                    "name": "Group Input.002",
+                                    "label": "",
+                                    "warning_propagation": "ALL",
+                                    "use_custom_color": false,
+                                    "color": [
+                                        0.6079999804496765,
+                                        0.6079999804496765,
+                                        0.6079999804496765
+                                    ],
+                                    "select": false,
+                                    "show_options": true,
+                                    "show_preview": false,
+                                    "hide": false,
+                                    "mute": false,
+                                    "show_texture": false,
+                                    "inputs": {
+                                        "id": 1041,
+                                        "data": {
+                                            "items": []
+                                        }
+                                    },
+                                    "outputs": {
+                                        "id": 1042,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 1043,
+                                                    "data": {
+                                                        "name": "Geometry",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "GEOMETRY",
+                                                        "display_shape": "LINE"
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1044,
+                                                    "data": {
+                                                        "name": "Grid Node Size",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 0.25
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1045,
+                                                    "data": {
+                                                        "name": "Display as",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "MENU",
+                                                        "display_shape": "LINE"
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1046,
+                                                    "data": {
+                                                        "name": "Coloring",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "MENU",
+                                                        "display_shape": "CIRCLE"
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1047,
+                                                    "data": {
+                                                        "name": "Divide by 10^x",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 3.0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1048,
+                                                    "data": {
+                                                        "name": "Collider Idx",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1049,
+                                                    "data": {
+                                                        "name": "Scale",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 1.0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1050,
+                                                    "data": {
+                                                        "name": "Threshold",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 0.5
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1051,
+                                                    "data": {
+                                                        "name": "Material",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "MATERIAL",
+                                                        "display_shape": "LINE",
+                                                        "default_value": null
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1052,
+                                                    "data": {
+                                                        "name": "Shade Smooth",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "DIAMOND",
+                                                        "default_value": true
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1053,
+                                                    "data": {
+                                                        "name": "Blur Iterations",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 1
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1054,
+                                                    "data": {
+                                                        "name": "Input Object",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "OBJECT",
+                                                        "display_shape": "LINE",
+                                                        "default_value": null
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1055,
+                                                    "data": {
+                                                        "name": "Skin",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "OBJECT",
+                                                        "display_shape": "LINE",
+                                                        "default_value": null
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1056,
+                                                    "data": {
+                                                        "name": "Failed Scale",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0.5
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1057,
+                                                    "data": {
+                                                        "name": "Velocity",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "LINE",
+                                                        "default_value": false
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1058,
+                                                    "data": {
+                                                        "name": "Velocity Scale",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 1.0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1059,
+                                                    "data": {
+                                                        "name": "",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "CUSTOM",
+                                                        "display_shape": "CIRCLE"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "bl_idname": "NodeGroupInput",
+                                    "parent": null
+                                }
+                            },
+                            {
+                                "id": 1060,
+                                "data": {
+                                    "location": [
+                                        960.0,
+                                        -80.0
+                                    ],
+                                    "location_absolute": [
+                                        960.0,
+                                        -80.0
+                                    ],
+                                    "width": 140.0,
+                                    "height": 100.0,
+                                    "name": "Group Input.003",
+                                    "label": "",
+                                    "warning_propagation": "ALL",
+                                    "use_custom_color": false,
+                                    "color": [
+                                        0.6079999804496765,
+                                        0.6079999804496765,
+                                        0.6079999804496765
+                                    ],
+                                    "select": false,
+                                    "show_options": true,
+                                    "show_preview": false,
+                                    "hide": false,
+                                    "mute": false,
+                                    "show_texture": false,
+                                    "inputs": {
+                                        "id": 1061,
+                                        "data": {
+                                            "items": []
+                                        }
+                                    },
+                                    "outputs": {
+                                        "id": 1062,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 1063,
+                                                    "data": {
+                                                        "name": "Geometry",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "GEOMETRY",
+                                                        "display_shape": "LINE"
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1064,
+                                                    "data": {
+                                                        "name": "Grid Node Size",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 0.25
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1065,
+                                                    "data": {
+                                                        "name": "Display as",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "MENU",
+                                                        "display_shape": "LINE"
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1066,
+                                                    "data": {
+                                                        "name": "Coloring",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "MENU",
+                                                        "display_shape": "CIRCLE"
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1067,
+                                                    "data": {
+                                                        "name": "Divide by 10^x",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 3.0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1068,
+                                                    "data": {
+                                                        "name": "Collider Idx",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1069,
+                                                    "data": {
+                                                        "name": "Scale",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 1.0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1070,
+                                                    "data": {
+                                                        "name": "Threshold",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 0.5
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1071,
+                                                    "data": {
+                                                        "name": "Material",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "MATERIAL",
+                                                        "display_shape": "LINE",
+                                                        "default_value": null
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1072,
+                                                    "data": {
+                                                        "name": "Shade Smooth",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "DIAMOND",
+                                                        "default_value": true
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1073,
+                                                    "data": {
+                                                        "name": "Blur Iterations",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 1
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1074,
+                                                    "data": {
+                                                        "name": "Input Object",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "OBJECT",
+                                                        "display_shape": "LINE",
+                                                        "default_value": null
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1075,
+                                                    "data": {
+                                                        "name": "Skin",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "OBJECT",
+                                                        "display_shape": "LINE",
+                                                        "default_value": null
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1076,
+                                                    "data": {
+                                                        "name": "Failed Scale",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0.5
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1077,
+                                                    "data": {
+                                                        "name": "Velocity",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "LINE",
+                                                        "default_value": false
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1078,
+                                                    "data": {
+                                                        "name": "Velocity Scale",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 1.0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1079,
+                                                    "data": {
+                                                        "name": "",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "CUSTOM",
+                                                        "display_shape": "CIRCLE"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "bl_idname": "NodeGroupInput",
+                                    "parent": null
+                                }
+                            },
+                            {
+                                "id": 1080,
+                                "data": {
+                                    "location": [
+                                        1200.0,
+                                        -180.0
+                                    ],
+                                    "location_absolute": [
+                                        1200.0,
+                                        -180.0
+                                    ],
+                                    "width": 140.0,
+                                    "height": 100.0,
+                                    "name": "Switch",
+                                    "label": "",
+                                    "warning_propagation": "ALL",
+                                    "use_custom_color": false,
+                                    "color": [
+                                        0.6079999804496765,
+                                        0.6079999804496765,
+                                        0.6079999804496765
+                                    ],
+                                    "select": false,
+                                    "show_options": true,
+                                    "show_preview": false,
+                                    "hide": false,
+                                    "mute": false,
+                                    "show_texture": false,
+                                    "inputs": {
+                                        "id": 1081,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 1082,
+                                                    "data": {
+                                                        "name": "Switch",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "LINE",
+                                                        "default_value": false
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1083,
+                                                    "data": {
+                                                        "name": "False",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "GEOMETRY",
+                                                        "display_shape": "LINE"
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1084,
+                                                    "data": {
+                                                        "name": "True",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "GEOMETRY",
+                                                        "display_shape": "LINE"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "outputs": {
+                                        "id": 1085,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 1086,
+                                                    "data": {
+                                                        "name": "Output",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "GEOMETRY",
+                                                        "display_shape": "LINE"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "bl_idname": "GeometryNodeSwitch",
+                                    "parent": null,
+                                    "input_type": "GEOMETRY"
+                                }
+                            },
+                            {
+                                "id": 1087,
+                                "data": {
+                                    "location": [
+                                        1400.0,
+                                        520.0
+                                    ],
+                                    "location_absolute": [
+                                        1400.0,
+                                        520.0
+                                    ],
+                                    "width": 140.0,
+                                    "height": 100.0,
+                                    "name": "Group Input.004",
+                                    "label": "",
+                                    "warning_propagation": "ALL",
+                                    "use_custom_color": false,
+                                    "color": [
+                                        0.6079999804496765,
+                                        0.6079999804496765,
+                                        0.6079999804496765
+                                    ],
+                                    "select": false,
+                                    "show_options": true,
+                                    "show_preview": false,
+                                    "hide": false,
+                                    "mute": false,
+                                    "show_texture": false,
+                                    "inputs": {
+                                        "id": 1088,
+                                        "data": {
+                                            "items": []
+                                        }
+                                    },
+                                    "outputs": {
+                                        "id": 1089,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 1090,
+                                                    "data": {
+                                                        "name": "Geometry",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "GEOMETRY",
+                                                        "display_shape": "LINE"
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1091,
+                                                    "data": {
+                                                        "name": "Grid Node Size",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 0.25
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1092,
+                                                    "data": {
+                                                        "name": "Display as",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "MENU",
+                                                        "display_shape": "LINE"
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1093,
+                                                    "data": {
+                                                        "name": "Coloring",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "MENU",
+                                                        "display_shape": "CIRCLE"
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1094,
+                                                    "data": {
+                                                        "name": "Divide by 10^x",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 3.0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1095,
+                                                    "data": {
+                                                        "name": "Collider Idx",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1096,
+                                                    "data": {
+                                                        "name": "Scale",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 1.0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1097,
+                                                    "data": {
+                                                        "name": "Threshold",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 0.5
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1098,
+                                                    "data": {
+                                                        "name": "Material",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "MATERIAL",
+                                                        "display_shape": "LINE",
+                                                        "default_value": null
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1099,
+                                                    "data": {
+                                                        "name": "Shade Smooth",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "DIAMOND",
+                                                        "default_value": true
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1100,
+                                                    "data": {
+                                                        "name": "Blur Iterations",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "INT",
+                                                        "display_shape": "LINE",
+                                                        "default_value": 1
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1101,
+                                                    "data": {
+                                                        "name": "Input Object",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "OBJECT",
+                                                        "display_shape": "LINE",
+                                                        "default_value": null
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1102,
+                                                    "data": {
+                                                        "name": "Skin",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "OBJECT",
+                                                        "display_shape": "LINE",
+                                                        "default_value": null
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1103,
+                                                    "data": {
+                                                        "name": "Failed Scale",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0.5
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1104,
+                                                    "data": {
+                                                        "name": "Velocity",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "LINE",
+                                                        "default_value": false
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1105,
+                                                    "data": {
+                                                        "name": "Velocity Scale",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 1.0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1106,
+                                                    "data": {
+                                                        "name": "",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "CUSTOM",
+                                                        "display_shape": "CIRCLE"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "bl_idname": "NodeGroupInput",
+                                    "parent": null
+                                }
+                            },
+                            {
+                                "id": 1107,
+                                "data": {
+                                    "location": [
                                         1360.0,
                                         -660.0
                                     ],
@@ -15949,11 +16911,11 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 1041,
+                                        "id": 1108,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 1042,
+                                                    "id": 1109,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -15968,7 +16930,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1043,
+                                                    "id": 1110,
                                                     "data": {
                                                         "name": "Input Object",
                                                         "description": "",
@@ -15984,7 +16946,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1044,
+                                                    "id": 1111,
                                                     "data": {
                                                         "name": "Skin",
                                                         "description": "",
@@ -16003,11 +16965,11 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 1045,
+                                        "id": 1112,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 1046,
+                                                    "id": 1113,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -16030,7 +16992,7 @@
                                 }
                             },
                             {
-                                "id": 1047,
+                                "id": 1114,
                                 "data": {
                                     "location": [
                                         1160.0,
@@ -16058,17 +17020,17 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 1048,
+                                        "id": 1115,
                                         "data": {
                                             "items": []
                                         }
                                     },
                                     "outputs": {
-                                        "id": 1049,
+                                        "id": 1116,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 1050,
+                                                    "id": 1117,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -16083,7 +17045,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1051,
+                                                    "id": 1118,
                                                     "data": {
                                                         "name": "Grid Node Size",
                                                         "description": "",
@@ -16099,7 +17061,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1052,
+                                                    "id": 1119,
                                                     "data": {
                                                         "name": "Display as",
                                                         "description": "",
@@ -16114,7 +17076,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1053,
+                                                    "id": 1120,
                                                     "data": {
                                                         "name": "Coloring",
                                                         "description": "",
@@ -16129,7 +17091,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1054,
+                                                    "id": 1121,
                                                     "data": {
                                                         "name": "Divide by 10^x",
                                                         "description": "",
@@ -16145,7 +17107,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1055,
+                                                    "id": 1122,
                                                     "data": {
                                                         "name": "Collider Idx",
                                                         "description": "",
@@ -16161,7 +17123,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1056,
+                                                    "id": 1123,
                                                     "data": {
                                                         "name": "Scale",
                                                         "description": "",
@@ -16177,7 +17139,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1057,
+                                                    "id": 1124,
                                                     "data": {
                                                         "name": "Threshold",
                                                         "description": "",
@@ -16193,7 +17155,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1058,
+                                                    "id": 1125,
                                                     "data": {
                                                         "name": "Material",
                                                         "description": "",
@@ -16209,7 +17171,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1059,
+                                                    "id": 1126,
                                                     "data": {
                                                         "name": "Shade Smooth",
                                                         "description": "",
@@ -16225,7 +17187,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1060,
+                                                    "id": 1127,
                                                     "data": {
                                                         "name": "Blur Iterations",
                                                         "description": "",
@@ -16241,7 +17203,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1061,
+                                                    "id": 1128,
                                                     "data": {
                                                         "name": "Input Object",
                                                         "description": "",
@@ -16257,7 +17219,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1062,
+                                                    "id": 1129,
                                                     "data": {
                                                         "name": "Skin",
                                                         "description": "",
@@ -16273,7 +17235,23 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1063,
+                                                    "id": 1130,
+                                                    "data": {
+                                                        "name": "Failed Scale",
+                                                        "description": "",
+                                                        "hide": true,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0.5
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1131,
                                                     "data": {
                                                         "name": "Velocity",
                                                         "description": "",
@@ -16289,7 +17267,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1064,
+                                                    "id": 1132,
                                                     "data": {
                                                         "name": "Velocity Scale",
                                                         "description": "",
@@ -16305,7 +17283,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1065,
+                                                    "id": 1133,
                                                     "data": {
                                                         "name": "",
                                                         "description": "",
@@ -16327,19 +17305,19 @@
                                 }
                             },
                             {
-                                "id": 1066,
+                                "id": 1134,
                                 "data": {
                                     "location": [
-                                        1220.0,
-                                        360.0
+                                        1400.0,
+                                        420.0
                                     ],
                                     "location_absolute": [
-                                        1220.0,
-                                        360.0
+                                        1400.0,
+                                        420.0
                                     ],
                                     "width": 140.0,
                                     "height": 100.0,
-                                    "name": "Mesh to Points",
+                                    "name": "Mesh to Points.001",
                                     "label": "",
                                     "warning_propagation": "ALL",
                                     "use_custom_color": false,
@@ -16355,11 +17333,11 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 1067,
+                                        "id": 1135,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 1068,
+                                                    "id": 1136,
                                                     "data": {
                                                         "name": "Mesh",
                                                         "description": "",
@@ -16374,7 +17352,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1069,
+                                                    "id": 1137,
                                                     "data": {
                                                         "name": "Selection",
                                                         "description": "",
@@ -16390,7 +17368,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1070,
+                                                    "id": 1138,
                                                     "data": {
                                                         "name": "Position",
                                                         "description": "",
@@ -16410,7 +17388,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1071,
+                                                    "id": 1139,
                                                     "data": {
                                                         "name": "Radius",
                                                         "description": "",
@@ -16429,11 +17407,11 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 1072,
+                                        "id": 1140,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 1073,
+                                                    "id": 1141,
                                                     "data": {
                                                         "name": "Points",
                                                         "description": "",
@@ -16456,19 +17434,19 @@
                                 }
                             },
                             {
-                                "id": 1074,
+                                "id": 1142,
                                 "data": {
                                     "location": [
-                                        600.0,
-                                        360.0
+                                        580.0,
+                                        380.0
                                     ],
                                     "location_absolute": [
-                                        600.0,
-                                        360.0
+                                        580.0,
+                                        380.0
                                     ],
                                     "width": 140.0,
                                     "height": 100.0,
-                                    "name": "Group Input.006",
+                                    "name": "Group Input.007",
                                     "label": "",
                                     "warning_propagation": "ALL",
                                     "use_custom_color": false,
@@ -16484,17 +17462,17 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 1075,
+                                        "id": 1143,
                                         "data": {
                                             "items": []
                                         }
                                     },
                                     "outputs": {
-                                        "id": 1076,
+                                        "id": 1144,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 1077,
+                                                    "id": 1145,
                                                     "data": {
                                                         "name": "Geometry",
                                                         "description": "",
@@ -16509,7 +17487,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1078,
+                                                    "id": 1146,
                                                     "data": {
                                                         "name": "Grid Node Size",
                                                         "description": "",
@@ -16525,7 +17503,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1079,
+                                                    "id": 1147,
                                                     "data": {
                                                         "name": "Display as",
                                                         "description": "",
@@ -16540,7 +17518,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1080,
+                                                    "id": 1148,
                                                     "data": {
                                                         "name": "Coloring",
                                                         "description": "",
@@ -16555,7 +17533,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1081,
+                                                    "id": 1149,
                                                     "data": {
                                                         "name": "Divide by 10^x",
                                                         "description": "",
@@ -16571,7 +17549,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1082,
+                                                    "id": 1150,
                                                     "data": {
                                                         "name": "Collider Idx",
                                                         "description": "",
@@ -16587,7 +17565,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1083,
+                                                    "id": 1151,
                                                     "data": {
                                                         "name": "Scale",
                                                         "description": "",
@@ -16603,7 +17581,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1084,
+                                                    "id": 1152,
                                                     "data": {
                                                         "name": "Threshold",
                                                         "description": "",
@@ -16619,7 +17597,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1085,
+                                                    "id": 1153,
                                                     "data": {
                                                         "name": "Material",
                                                         "description": "",
@@ -16635,7 +17613,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1086,
+                                                    "id": 1154,
                                                     "data": {
                                                         "name": "Shade Smooth",
                                                         "description": "",
@@ -16651,7 +17629,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1087,
+                                                    "id": 1155,
                                                     "data": {
                                                         "name": "Blur Iterations",
                                                         "description": "",
@@ -16667,7 +17645,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1088,
+                                                    "id": 1156,
                                                     "data": {
                                                         "name": "Input Object",
                                                         "description": "",
@@ -16683,7 +17661,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1089,
+                                                    "id": 1157,
                                                     "data": {
                                                         "name": "Skin",
                                                         "description": "",
@@ -16699,7 +17677,23 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1090,
+                                                    "id": 1158,
+                                                    "data": {
+                                                        "name": "Failed Scale",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0.5
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1159,
                                                     "data": {
                                                         "name": "Velocity",
                                                         "description": "",
@@ -16715,7 +17709,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1091,
+                                                    "id": 1160,
                                                     "data": {
                                                         "name": "Velocity Scale",
                                                         "description": "",
@@ -16731,7 +17725,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1092,
+                                                    "id": 1161,
                                                     "data": {
                                                         "name": "",
                                                         "description": "",
@@ -16753,19 +17747,19 @@
                                 }
                             },
                             {
-                                "id": 1093,
+                                "id": 1162,
                                 "data": {
                                     "location": [
-                                        760.0,
-                                        120.0
+                                        980.0,
+                                        100.0
                                     ],
                                     "location_absolute": [
-                                        760.0,
-                                        120.0
+                                        980.0,
+                                        100.0
                                     ],
                                     "width": 180.0,
                                     "height": 100.0,
-                                    "name": "Named Attribute.001",
+                                    "name": "Named Attribute.002",
                                     "label": "",
                                     "warning_propagation": "ALL",
                                     "use_custom_color": false,
@@ -16781,11 +17775,11 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 1094,
+                                        "id": 1163,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 1095,
+                                                    "id": 1164,
                                                     "data": {
                                                         "name": "Name",
                                                         "description": "",
@@ -16804,11 +17798,11 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 1096,
+                                        "id": 1165,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 1097,
+                                                    "id": 1166,
                                                     "data": {
                                                         "name": "Attribute",
                                                         "description": "",
@@ -16824,7 +17818,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1098,
+                                                    "id": 1167,
                                                     "data": {
                                                         "name": "Exists",
                                                         "description": "",
@@ -16848,19 +17842,19 @@
                                 }
                             },
                             {
-                                "id": 1099,
+                                "id": 1168,
                                 "data": {
                                     "location": [
-                                        800.0,
-                                        280.0
+                                        1020.0,
+                                        300.0
                                     ],
                                     "location_absolute": [
-                                        800.0,
-                                        280.0
+                                        1020.0,
+                                        300.0
                                     ],
                                     "width": 140.0,
                                     "height": 100.0,
-                                    "name": "Math",
+                                    "name": "Math.002",
                                     "label": "",
                                     "warning_propagation": "ALL",
                                     "use_custom_color": false,
@@ -16876,11 +17870,11 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 1100,
+                                        "id": 1169,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 1101,
+                                                    "id": 1170,
                                                     "data": {
                                                         "name": "Value",
                                                         "description": "",
@@ -16896,7 +17890,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1102,
+                                                    "id": 1171,
                                                     "data": {
                                                         "name": "Value",
                                                         "description": "",
@@ -16912,7 +17906,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1103,
+                                                    "id": 1172,
                                                     "data": {
                                                         "name": "Value",
                                                         "description": "",
@@ -16931,11 +17925,11 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 1104,
+                                        "id": 1173,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 1105,
+                                                    "id": 1174,
                                                     "data": {
                                                         "name": "Value",
                                                         "description": "",
@@ -16960,19 +17954,19 @@
                                 }
                             },
                             {
-                                "id": 1106,
+                                "id": 1175,
                                 "data": {
                                     "location": [
-                                        1020.0,
-                                        240.0
+                                        1200.0,
+                                        300.0
                                     ],
                                     "location_absolute": [
-                                        1020.0,
-                                        240.0
+                                        1200.0,
+                                        300.0
                                     ],
                                     "width": 140.0,
                                     "height": 100.0,
-                                    "name": "Math.001",
+                                    "name": "Math.003",
                                     "label": "",
                                     "warning_propagation": "ALL",
                                     "use_custom_color": false,
@@ -16988,11 +17982,11 @@
                                     "mute": false,
                                     "show_texture": false,
                                     "inputs": {
-                                        "id": 1107,
+                                        "id": 1176,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 1108,
+                                                    "id": 1177,
                                                     "data": {
                                                         "name": "Value",
                                                         "description": "",
@@ -17008,7 +18002,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1109,
+                                                    "id": 1178,
                                                     "data": {
                                                         "name": "Value",
                                                         "description": "",
@@ -17024,7 +18018,7 @@
                                                     }
                                                 },
                                                 {
-                                                    "id": 1110,
+                                                    "id": 1179,
                                                     "data": {
                                                         "name": "Value",
                                                         "description": "",
@@ -17043,11 +18037,11 @@
                                         }
                                     },
                                     "outputs": {
-                                        "id": 1111,
+                                        "id": 1180,
                                         "data": {
                                             "items": [
                                                 {
-                                                    "id": 1112,
+                                                    "id": 1181,
                                                     "data": {
                                                         "name": "Value",
                                                         "description": "",
@@ -17069,6 +18063,196 @@
                                     "parent": null,
                                     "operation": "MULTIPLY",
                                     "use_clamp": false
+                                }
+                            },
+                            {
+                                "id": 1182,
+                                "data": {
+                                    "location": [
+                                        480.0,
+                                        240.0
+                                    ],
+                                    "location_absolute": [
+                                        480.0,
+                                        240.0
+                                    ],
+                                    "width": 260.0,
+                                    "height": 100.0,
+                                    "name": "Group.005",
+                                    "label": "",
+                                    "warning_propagation": "ALL",
+                                    "use_custom_color": false,
+                                    "color": [
+                                        0.6079999804496765,
+                                        0.6079999804496765,
+                                        0.6079999804496765
+                                    ],
+                                    "select": false,
+                                    "show_options": true,
+                                    "show_preview": false,
+                                    "hide": false,
+                                    "mute": false,
+                                    "show_texture": false,
+                                    "inputs": {
+                                        "id": 1183,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 1184,
+                                                    "data": {
+                                                        "name": "Flag",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "MENU",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": "FAILED"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "outputs": {
+                                        "id": 1185,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 1186,
+                                                    "data": {
+                                                        "name": "Value",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "bl_idname": "GeometryNodeGroup",
+                                    "parent": null,
+                                    "node_tree": 851
+                                }
+                            },
+                            {
+                                "id": 1187,
+                                "data": {
+                                    "location": [
+                                        840.0,
+                                        300.0
+                                    ],
+                                    "location_absolute": [
+                                        840.0,
+                                        300.0
+                                    ],
+                                    "width": 140.0,
+                                    "height": 100.0,
+                                    "name": "Switch.001",
+                                    "label": "",
+                                    "warning_propagation": "ALL",
+                                    "use_custom_color": false,
+                                    "color": [
+                                        0.6079999804496765,
+                                        0.6079999804496765,
+                                        0.6079999804496765
+                                    ],
+                                    "select": false,
+                                    "show_options": true,
+                                    "show_preview": false,
+                                    "hide": false,
+                                    "mute": false,
+                                    "show_texture": false,
+                                    "inputs": {
+                                        "id": 1188,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 1189,
+                                                    "data": {
+                                                        "name": "Switch",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "BOOLEAN",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": false
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1190,
+                                                    "data": {
+                                                        "name": "False",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0.0
+                                                    }
+                                                },
+                                                {
+                                                    "id": 1191,
+                                                    "data": {
+                                                        "name": "True",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 1,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0.0
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "outputs": {
+                                        "id": 1192,
+                                        "data": {
+                                            "items": [
+                                                {
+                                                    "id": 1193,
+                                                    "data": {
+                                                        "name": "Output",
+                                                        "description": "",
+                                                        "hide": false,
+                                                        "enabled": true,
+                                                        "link_limit": 4095,
+                                                        "show_expanded": false,
+                                                        "hide_value": false,
+                                                        "pin_gizmo": false,
+                                                        "type": "VALUE",
+                                                        "display_shape": "CIRCLE",
+                                                        "default_value": 0.0
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "bl_idname": "GeometryNodeSwitch",
+                                    "parent": null,
+                                    "input_type": "FLOAT"
                                 }
                             }
                         ]
@@ -17077,315 +18261,342 @@
                 "bl_idname": "GeometryNodeTree",
                 "annotation": null,
                 "links": {
-                    "id": 1113,
+                    "id": 1194,
                     "data": {
                         "items": [
                             {
-                                "id": 1114,
+                                "id": 1195,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 875,
-                                    "to_socket": 913
+                                    "from_socket": 937,
+                                    "to_socket": 976
                                 }
                             },
                             {
-                                "id": 1115,
+                                "id": 1196,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 889,
-                                    "to_socket": 914
+                                    "from_socket": 952,
+                                    "to_socket": 977
                                 }
                             },
                             {
-                                "id": 1116,
+                                "id": 1197,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 896,
-                                    "to_socket": 899
+                                    "from_socket": 959,
+                                    "to_socket": 962
                                 }
                             },
                             {
-                                "id": 1117,
+                                "id": 1198,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 909,
-                                    "to_socket": 915
+                                    "from_socket": 972,
+                                    "to_socket": 978
                                 }
                             },
                             {
-                                "id": 1118,
+                                "id": 1199,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
                                     "multi_input_sort_id": 0,
-                                    "from_socket": 917,
-                                    "to_socket": 930
-                                }
-                            },
-                            {
-                                "id": 1119,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "from_socket": 1020,
-                                    "to_socket": 937
-                                }
-                            },
-                            {
-                                "id": 1120,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "from_socket": 927,
-                                    "to_socket": 938
-                                }
-                            },
-                            {
-                                "id": 1121,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "from_socket": 942,
-                                    "to_socket": 954
-                                }
-                            },
-                            {
-                                "id": 1122,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "multi_input_sort_id": 1,
-                                    "from_socket": 904,
-                                    "to_socket": 930
-                                }
-                            },
-                            {
-                                "id": 1123,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "from_socket": 960,
-                                    "to_socket": 893
-                                }
-                            },
-                            {
-                                "id": 1124,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "from_socket": 966,
-                                    "to_socket": 894
-                                }
-                            },
-                            {
-                                "id": 1125,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "from_socket": 963,
-                                    "to_socket": 900
-                                }
-                            },
-                            {
-                                "id": 1126,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "from_socket": 964,
-                                    "to_socket": 901
-                                }
-                            },
-                            {
-                                "id": 1127,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "from_socket": 965,
-                                    "to_socket": 902
-                                }
-                            },
-                            {
-                                "id": 1128,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "from_socket": 979,
-                                    "to_socket": 920
-                                }
-                            },
-                            {
-                                "id": 1129,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
                                     "from_socket": 980,
-                                    "to_socket": 921
+                                    "to_socket": 993
                                 }
                             },
                             {
-                                "id": 1130,
+                                "id": 1200,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 986,
-                                    "to_socket": 922
+                                    "from_socket": 1086,
+                                    "to_socket": 1000
                                 }
                             },
                             {
-                                "id": 1131,
+                                "id": 1201,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 987,
-                                    "to_socket": 923
+                                    "from_socket": 990,
+                                    "to_socket": 1001
                                 }
                             },
                             {
-                                "id": 1132,
+                                "id": 1202,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 988,
-                                    "to_socket": 924
-                                }
-                            },
-                            {
-                                "id": 1133,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "from_socket": 989,
-                                    "to_socket": 925
-                                }
-                            },
-                            {
-                                "id": 1134,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "from_socket": 932,
-                                    "to_socket": 1018
-                                }
-                            },
-                            {
-                                "id": 1135,
-                                "data": {
-                                    "is_valid": true,
-                                    "is_muted": false,
-                                    "from_socket": 904,
+                                    "from_socket": 1005,
                                     "to_socket": 1017
                                 }
                             },
                             {
-                                "id": 1136,
+                                "id": 1203,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 1011,
-                                    "to_socket": 1016
+                                    "multi_input_sort_id": 1,
+                                    "from_socket": 967,
+                                    "to_socket": 993
                                 }
                             },
                             {
-                                "id": 1137,
+                                "id": 1204,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1023,
+                                    "to_socket": 956
+                                }
+                            },
+                            {
+                                "id": 1205,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1029,
+                                    "to_socket": 957
+                                }
+                            },
+                            {
+                                "id": 1206,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
                                     "from_socket": 1026,
-                                    "to_socket": 935
+                                    "to_socket": 963
                                 }
                             },
                             {
-                                "id": 1138,
+                                "id": 1207,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 1061,
-                                    "to_socket": 1043
+                                    "from_socket": 1027,
+                                    "to_socket": 964
                                 }
                             },
                             {
-                                "id": 1139,
+                                "id": 1208,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 1062,
-                                    "to_socket": 1044
+                                    "from_socket": 1028,
+                                    "to_socket": 965
                                 }
                             },
                             {
-                                "id": 1140,
+                                "id": 1209,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1043,
+                                    "to_socket": 983
+                                }
+                            },
+                            {
+                                "id": 1210,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1044,
+                                    "to_socket": 984
+                                }
+                            },
+                            {
+                                "id": 1211,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
                                     "from_socket": 1050,
-                                    "to_socket": 1042
+                                    "to_socket": 985
                                 }
                             },
                             {
-                                "id": 1141,
+                                "id": 1212,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 1046,
-                                    "to_socket": 939
+                                    "from_socket": 1051,
+                                    "to_socket": 986
                                 }
                             },
                             {
-                                "id": 1142,
+                                "id": 1213,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1052,
+                                    "to_socket": 987
+                                }
+                            },
+                            {
+                                "id": 1214,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1053,
+                                    "to_socket": 988
+                                }
+                            },
+                            {
+                                "id": 1215,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 995,
+                                    "to_socket": 1084
+                                }
+                            },
+                            {
+                                "id": 1216,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 967,
+                                    "to_socket": 1083
+                                }
+                            },
+                            {
+                                "id": 1217,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
                                     "from_socket": 1077,
-                                    "to_socket": 1068
+                                    "to_socket": 1082
                                 }
                             },
                             {
-                                "id": 1143,
+                                "id": 1218,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 1073,
-                                    "to_socket": 936
+                                    "from_socket": 1092,
+                                    "to_socket": 998
                                 }
                             },
                             {
-                                "id": 1144,
+                                "id": 1219,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 1083,
-                                    "to_socket": 1101
+                                    "from_socket": 1128,
+                                    "to_socket": 1110
                                 }
                             },
                             {
-                                "id": 1145,
+                                "id": 1220,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 1097,
+                                    "from_socket": 1129,
+                                    "to_socket": 1111
+                                }
+                            },
+                            {
+                                "id": 1221,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1117,
                                     "to_socket": 1109
                                 }
                             },
                             {
-                                "id": 1146,
+                                "id": 1222,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 1105,
-                                    "to_socket": 1108
+                                    "from_socket": 1113,
+                                    "to_socket": 1002
                                 }
                             },
                             {
-                                "id": 1147,
+                                "id": 1223,
                                 "data": {
                                     "is_valid": true,
                                     "is_muted": false,
-                                    "from_socket": 1112,
-                                    "to_socket": 1071
+                                    "from_socket": 1145,
+                                    "to_socket": 1136
+                                }
+                            },
+                            {
+                                "id": 1224,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1174,
+                                    "to_socket": 1177
+                                }
+                            },
+                            {
+                                "id": 1225,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1181,
+                                    "to_socket": 1139
+                                }
+                            },
+                            {
+                                "id": 1226,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1193,
+                                    "to_socket": 1170
+                                }
+                            },
+                            {
+                                "id": 1227,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1166,
+                                    "to_socket": 1178
+                                }
+                            },
+                            {
+                                "id": 1228,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1186,
+                                    "to_socket": 1189
+                                }
+                            },
+                            {
+                                "id": 1229,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1151,
+                                    "to_socket": 1190
+                                }
+                            },
+                            {
+                                "id": 1230,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1158,
+                                    "to_socket": 1191
+                                }
+                            },
+                            {
+                                "id": 1231,
+                                "data": {
+                                    "is_valid": true,
+                                    "is_muted": false,
+                                    "from_socket": 1141,
+                                    "to_socket": 999
                                 }
                             }
                         ]
@@ -17407,7 +18618,7 @@
         }
     ],
     "external": {
-        "1148": {
+        "1232": {
             "description": "Hint for Import",
             "fixed_type_name": "Material",
             "scene_id": null

--- a/python/src/squishy_volumes_extension/squishy_volumes_properties/object_output.py
+++ b/python/src/squishy_volumes_extension/squishy_volumes_properties/object_output.py
@@ -109,7 +109,7 @@ class Squishy_Volumes_Properties_Output(bpy.types.PropertyGroup):
     particle_flags: bpy.props.BoolProperty(
         name="Flags",
         description=f"Attribute name: {SQUISHY_VOLUMES_FLAGS}",
-        default=False,
+        default=True,
         options=set(),
     )  # type: ignore
 

--- a/rust/crates/core/src/compute_thread.rs
+++ b/rust/crates/core/src/compute_thread.rs
@@ -123,28 +123,42 @@ impl ComputeThread {
 
                     let target_time = next_frame as f64 / consts.frames_per_second as f64;
 
+                    let result: Result<(), Error>;
                     let io_state = match &mut compute_state {
-                        ComputeState::Cpu(cpu_state) => cpu_state.produce_next_state(
-                            &harness,
-                            &frame_input,
-                            CpuRunParameters {
-                                target_time,
-                                max_time_step,
-                                adaptive_time_steps,
-                                store_grid: true,
-                            },
-                        )?,
-                        ComputeState::Gpu(gpu_state) => gpu_state.produce_next_state(
-                            &harness,
-                            &mut frame_input,
-                            GpuRunParameters {
-                                target_time,
-                                store_grid: true,
-                            },
-                        )?,
+                        ComputeState::Cpu(cpu_state) => {
+                            let (io_state, cpu_result) = cpu_state.produce_next_state(
+                                &harness,
+                                &frame_input,
+                                CpuRunParameters {
+                                    target_time,
+                                    max_time_step,
+                                    adaptive_time_steps,
+                                    store_grid: true,
+                                },
+                            )?;
+                            result = cpu_result.map_err(Error::CpuCompute);
+                            io_state
+                        }
+                        ComputeState::Gpu(gpu_state) => {
+                            let (io_state, gpu_result) = gpu_state.produce_next_state(
+                                &harness,
+                                &mut frame_input,
+                                GpuRunParameters {
+                                    target_time,
+                                    store_grid: true,
+                                },
+                            )?;
+                            result = gpu_result.map_err(Error::GpuError);
+                            io_state
+                        }
                     };
 
+                    // store state even if error occured
                     cache.store_frame(io_state).map_err(Error::StoreError)?;
+
+                    // now check for errors
+                    result?;
+
                     info!("computed frame {} of {}", next_frame, number_of_frames);
 
                     next_frame += 1;

--- a/rust/crates/cpu/src/cpu_state.rs
+++ b/rust/crates/cpu/src/cpu_state.rs
@@ -165,9 +165,7 @@ impl CpuState {
         self.adaptive_time_step_state.max_time_step = max_time_step;
 
         while self.time < target_time {
-            if harness.is_canceled() {
-                return Err(Error::Canceled);
-            }
+            harness.check()?;
 
             if self.adaptive_time_step_state.allowed_time_step() == 0. {
                 return Err(Error::ZeroTimeStep);

--- a/rust/crates/cpu/src/cpu_state.rs
+++ b/rust/crates/cpu/src/cpu_state.rs
@@ -153,8 +153,9 @@ impl CpuState {
             adaptive_time_steps,
             store_grid,
         }: CpuRunParameters,
-    ) -> Result<squishy_volumes_file_frame::IoState, Error> {
+    ) -> Result<(squishy_volumes_file_frame::IoState, Result<(), Error>), Error> {
         squishy_volumes_util::profile!("produce_next_state");
+
         let harness = harness.scope(
             "Simulation Milliseconds to Next Frame".to_string(),
             NonZero::new(((1000. * frame_input.consts().seconds_per_frame()) as usize).max(1))
@@ -176,7 +177,13 @@ impl CpuState {
                 || (self.phase != Phase::LimitTimeStepBeforeForce
                     && self.phase != Phase::LimitTimeStepBeforeIntegrate);
             if run_phase {
-                self.run_phase(frame_input)?;
+                match self.run_phase(frame_input) {
+                    error @ Err(Error::EnergyError(energy_error)) => {
+                        tracing::warn!(?energy_error, "Encountered an energy error.");
+                        return Ok((self.to_io_state(store_grid)?, error));
+                    }
+                    x => x?,
+                }
             }
 
             self.phase = self.phase.cycle();
@@ -188,6 +195,6 @@ impl CpuState {
             )?;
         }
 
-        self.to_io_state(store_grid)
+        Ok((self.to_io_state(store_grid)?, Ok(())))
     }
 }

--- a/rust/crates/cpu/src/phase/advance_particles.rs
+++ b/rust/crates/cpu/src/phase/advance_particles.rs
@@ -26,12 +26,15 @@ impl CpuState {
             .zip(&mut self.particles.position_gradients)
             .zip(&self.particles.velocities)
             .zip(&self.particles.velocity_gradients)
-            .zip(&self.particles.flags)
-            .filter_map(|(e, flags)| (!flags.contains(ParticleFlags::TOMBSTONED)).then_some(e))
+            .zip(&mut self.particles.flags)
+            .filter(|(_, flags)| !flags.contains(ParticleFlags::TOMBSTONED))
             .try_for_each(
                 |(
-                    ((((elastic_energy, parameters), position), position_gradient), velocity),
-                    velocity_gradient,
+                    (
+                        ((((elastic_energy, parameters), position), position_gradient), velocity),
+                        velocity_gradient,
+                    ),
+                    flags,
                 )|
                  -> Result<(), Error> {
                     *position += velocity * time_step;
@@ -67,7 +70,8 @@ impl CpuState {
                                 }
                             }
 
-                            try_elastic_energy_neo_hookean(mu, lambda, position_gradient)?
+                            try_elastic_energy_neo_hookean(mu, lambda, position_gradient)
+                                .inspect_err(|_| *flags |= ParticleFlags::FAILED)?
                         }
                         SpecificParticleParameters::Fluid {
                             exponent,

--- a/rust/crates/file_frame/src/particles.rs
+++ b/rust/crates/file_frame/src/particles.rs
@@ -28,6 +28,7 @@ bitflags::bitflags! {
         const USE_SAND_ALPHA = 1 << 3;
         const HAS_GOAL = 1 << 4;
         const TOMBSTONED = 1 << 5;
+        const FAILED = 1 << 6;
     }
 }
 

--- a/rust/crates/gpu/src/gpu_state.rs
+++ b/rust/crates/gpu/src/gpu_state.rs
@@ -382,6 +382,10 @@ impl GpuState {
                 output.indirect_nodes,
                 self.next_input
                     .variable_particle_input
+                    .particle_flags
+                    .clone(),
+                self.next_input
+                    .variable_particle_input
                     .particle_positions_and_collider_bits
                     .clone(),
                 self.next_input
@@ -494,6 +498,7 @@ impl GpuState {
         let [
             status,
             indirect_nodes_download,
+            particle_flags,
             particle_positions_and_collider_bits,
             particle_position_gradients,
             particle_velocities,
@@ -561,6 +566,7 @@ impl GpuState {
             particle_positions_and_collider_bits.to_vec()?;
 
         self.io_state.time = self.time;
+        self.io_state.particles.flags = particle_flags.to_vec()?;
         self.io_state.particles.collider_bits = particle_positions_and_collider_bits
             .iter()
             .map(|position_and_bits| position_and_bits.collider_bits)

--- a/rust/crates/gpu/src/gpu_state.rs
+++ b/rust/crates/gpu/src/gpu_state.rs
@@ -327,11 +327,11 @@ impl GpuState {
             target_time,
             store_grid,
         }: GpuRunParameters,
-    ) -> Result<squishy_volumes_file_frame::IoState, GpuError> {
+    ) -> Result<(squishy_volumes_file_frame::IoState, Result<(), GpuError>), GpuError> {
         squishy_volumes_util::profile!("produce_next_state");
 
         if self.time >= target_time {
-            return Ok(self.io_state.clone());
+            return Ok((self.io_state.clone(), Ok(())));
         }
 
         let mut encoder = self
@@ -508,6 +508,7 @@ impl GpuState {
         tracing::info!(self.max_num_grid_nodes, num_grid_nodes);
 
         let mut redo_frame = false;
+        let mut buffered_error = Ok(());
         match status.to_vec::<GpuStatus>()?[0].to_result(&self.gpu_context) {
             Err(GpuError::Shader(GpuShaderError::IndirectLimitExceeded { reporting_shader })) => {
                 tracing::warn!(
@@ -519,6 +520,12 @@ impl GpuState {
             Err(GpuError::Shader(GpuShaderError::TableTriesExceeded { reporting_shader })) => {
                 tracing::warn!(reporting_shader, "The hash table appears to be too small.");
                 redo_frame = true;
+            }
+            error @ Err(GpuError::Shader(GpuShaderError::ParticleCloseToInverted {
+                reporting_shader,
+            })) => {
+                tracing::warn!(reporting_shader, "A particle is too close to inversion.");
+                buffered_error = error;
             }
             x => x?,
         };
@@ -631,6 +638,6 @@ impl GpuState {
             })
             .transpose()?;
 
-        Ok(self.io_state.clone())
+        Ok((self.io_state.clone(), buffered_error))
     }
 }

--- a/rust/crates/gpu/src/shaders/prepare_tmp.wesl
+++ b/rust/crates/gpu/src/shaders/prepare_tmp.wesl
@@ -6,7 +6,7 @@
 // license that can be found in the LICENSE_MIT file or at
 // https://opensource.org/licenses/MIT.
 
-import super::util::{PositionAndColliderBits, get_global_index, first_piola_stress_neo_hookean, first_piola_stress_inviscid, ParticleParameters, IS_SOLID, IS_FLUID, USE_SAND_ALPHA, USE_VISCOSITY, INVERSE_EPS, PARTICLE_CLOSE_TO_INVERTED};
+import super::util::{PositionAndColliderBits, get_global_index, first_piola_stress_neo_hookean, first_piola_stress_inviscid, ParticleParameters, IS_SOLID, IS_FLUID, USE_SAND_ALPHA, USE_VISCOSITY, INVERSE_EPS, PARTICLE_CLOSE_TO_INVERTED, FAILED};
 import super::sand::sand_plasticity;
 import super::fluid::fluid_plasticity;
 import super::viscosity::cauchy_stress_general_viscosity;
@@ -69,6 +69,7 @@ fn main(
 
     if determinant(position_gradient) < INVERSE_EPS {
         atomicOr(&status, PARTICLE_CLOSE_TO_INVERTED);
+        flags[global_index] |= FAILED;
         return;
     }
 

--- a/rust/crates/gpu/src/shaders/util.wesl
+++ b/rust/crates/gpu/src/shaders/util.wesl
@@ -211,6 +211,7 @@ const USE_VISCOSITY: u32 = 1 << 2;
 const USE_SAND_ALPHA: u32 = 1 << 3;
 const HAS_GOAL: u32 = 1 << 4;
 const TOMBSTONED: u32 = 1 << 5;
+const FAILED: u32 = 1 << 6;
 
 fn invariant_2(position_gradient: mat3x3f) -> f32 {
     return dot(position_gradient[0], position_gradient[0]) +


### PR DESCRIPTION
Fixes #18 

With this, it's much easier, or even possible in the first place, to locate the failed particles.

If an error related to a single particle occurs, the fail bit can now be set in the flags.
Even though the computation stops, the final state is stored and can be inspected in Blender.
The default visualization has a separate scaling for failed particles.