### PR TITLE
Fix Vertex Normals

### DIFF
--- a/rust/crates/cpu/src/phase/interpolate_input.rs
+++ b/rust/crates/cpu/src/phase/interpolate_input.rs
@@ -18,6 +18,7 @@ impl CpuState {
     pub fn interpolate_input(&mut self, frame_input: &FrameInput) -> Result<(), Error> {
         profile!("interpolate_input");
 
+        let triangle_indices = frame_input.topology().triangle_indices();
         let a = frame_input.a();
         let b = frame_input.b().unwrap_or(a);
 
@@ -41,9 +42,7 @@ impl CpuState {
             .map(|(a, b)| factor_a * a + factor_b * b)
             .collect();
 
-        let triangle_normals: Vec<Vector3<f32>> = frame_input
-            .topology()
-            .triangle_indices()
+        let triangle_normals: Vec<Vector3<f32>> = triangle_indices
             .par_iter()
             .map(|Triangle { a, b, c }| {
                 let a = &vertex_positions[*a as usize];
@@ -56,14 +55,25 @@ impl CpuState {
             })
             .collect();
 
+        // Important to weigh the normals by angle
+        // https://github.com/Algebraic-UG/squishy_volumes/issues/313
         let vertex_normals: Vec<Vector3<f32>> = frame_input
             .topology()
             .vertex_triangle_lists()
             .par_iter()
-            .map(|triangles| {
+            .enumerate()
+            .map(|(vertex_index, triangles)| {
                 triangles
                     .iter()
-                    .map(|triangle_index| triangle_normals[*triangle_index as usize])
+                    .map(|triangle_index| {
+                        let triangle = triangle_indices[*triangle_index as usize];
+                        let mut others = triangle.iter().filter(|&&i| i != vertex_index as u32);
+                        let p = vertex_positions[vertex_index];
+                        let a = vertex_positions[*others.next().unwrap() as usize];
+                        let b = vertex_positions[*others.next().unwrap() as usize];
+                        let angle = (a - p).angle(&(b - p));
+                        angle * triangle_normals[*triangle_index as usize]
+                    })
                     .sum::<Vector3<f32>>()
                     .try_normalize(NORMALIZATION_EPS)
                     .unwrap_or(Vector3::zeros())

--- a/rust/crates/gpu/src/animate_mesh/mod.rs
+++ b/rust/crates/gpu/src/animate_mesh/mod.rs
@@ -159,7 +159,9 @@ impl PipelinePart for AnimateMesh {
                 bind_group_entries: [
                     (u32::MIN_BINDING_SIZE, false),            // vertex_triangle_offsets
                     (u32::MIN_BINDING_SIZE, false),            // vertex_triangle_lists
+                    (Vector4::<f32>::MIN_BINDING_SIZE, false), // vertex_positions
                     (Vector4::<f32>::MIN_BINDING_SIZE, false), // vertex_normals
+                    (Triangle::MIN_BINDING_SIZE, false),       // triangle_indices
                     (Vector4::<f32>::MIN_BINDING_SIZE, false), // triangle_normals
                 ],
                 immediate_size: 0,
@@ -257,7 +259,9 @@ impl PipelinePart for AnimateMesh {
                     [
                         vertex_triangle_offsets.binding(),
                         vertex_triangle_lists.binding(),
+                        vertex_positions.binding(),
                         vertex_normals.binding(),
+                        triangle_indices.binding(),
                         triangle_normals.binding(),
                     ],
                 )

--- a/rust/crates/gpu/src/animate_mesh/test.rs
+++ b/rust/crates/gpu/src/animate_mesh/test.rs
@@ -121,6 +121,19 @@ fn torus() {
     });
 }
 
+#[test]
+fn cone() {
+    let vertices_0 = cone::vertices();
+    let vertices_1 = cone::vertices();
+    let triangles = cone::triangles();
+
+    check(InputData {
+        vertex_positions_start: &vertices_0,
+        vertex_positions_end: &vertices_1,
+        triangle_indices: &triangles,
+    });
+}
+
 fn run(
     settings: Settings,
     input_data: InputData,

--- a/rust/crates/gpu/src/animate_mesh/test.rs
+++ b/rust/crates/gpu/src/animate_mesh/test.rs
@@ -43,11 +43,20 @@ fn check(
             .collect::<Vec<_>>();
         let cpu_vertex_normals = vertex_triangle_lists
             .iter()
-            .map(|triangles| {
+            .enumerate()
+            .map(|(vertex_index, triangles)| {
                 let mut normal = Vector3::zeros();
                 for index in triangles.iter() {
-                    normal += cpu_triangle_normals[*index as usize];
+                    let triangle = triangle_indices[*index as usize];
+                    let mut others = triangle.iter().filter(|&&i| i != vertex_index as u32);
+                    let p = cpu_vertex_positions[vertex_index];
+                    let a = cpu_vertex_positions[*others.next().unwrap() as usize];
+                    let b = cpu_vertex_positions[*others.next().unwrap() as usize];
+                    let angle = (a - p).angle(&(b - p));
+
+                    normal += angle * cpu_triangle_normals[*index as usize];
                 }
+
                 normal
                     .try_normalize(NORMALIZATION_EPS)
                     .unwrap_or(Vector3::zeros())

--- a/rust/crates/gpu/src/cone.rs
+++ b/rust/crates/gpu/src/cone.rs
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright 2025  Algebraic UG (haftungsbeschränkt)
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE_MIT file or at
+// https://opensource.org/licenses/MIT.
+
+use nalgebra::{Vector3, Vector4};
+use squishy_volumes_mesh_util::Triangle;
+
+pub fn vertices() -> Vec<Vector4<f32>> {
+    #[allow(clippy::excessive_precision, clippy::approx_constant)]
+    [
+        Vector3::new(0.000000, -1.000000, -1.000000),
+        Vector3::new(0.195090, -1.000000, -0.980785),
+        Vector3::new(0.382683, -1.000000, -0.923880),
+        Vector3::new(0.555570, -1.000000, -0.831470),
+        Vector3::new(0.707107, -1.000000, -0.707107),
+        Vector3::new(0.831470, -1.000000, -0.555570),
+        Vector3::new(0.923880, -1.000000, -0.382683),
+        Vector3::new(0.980785, -1.000000, -0.195090),
+        Vector3::new(1.000000, -1.000000, 0.000000),
+        Vector3::new(0.980785, -1.000000, 0.195090),
+        Vector3::new(0.923880, -1.000000, 0.382683),
+        Vector3::new(0.831470, -1.000000, 0.555570),
+        Vector3::new(0.707107, -1.000000, 0.707107),
+        Vector3::new(0.555570, -1.000000, 0.831470),
+        Vector3::new(0.382683, -1.000000, 0.923880),
+        Vector3::new(0.195090, -1.000000, 0.980785),
+        Vector3::new(0.000000, -1.000000, 1.000000),
+        Vector3::new(-0.195090, -1.000000, 0.980785),
+        Vector3::new(-0.382683, -1.000000, 0.923880),
+        Vector3::new(-0.555570, -1.000000, 0.831470),
+        Vector3::new(-0.707107, -1.000000, 0.707107),
+        Vector3::new(-0.831470, -1.000000, 0.555570),
+        Vector3::new(-0.923880, -1.000000, 0.382683),
+        Vector3::new(-0.980785, -1.000000, 0.195090),
+        Vector3::new(-1.000000, -1.000000, 0.000000),
+        Vector3::new(-0.980785, -1.000000, -0.195090),
+        Vector3::new(-0.923880, -1.000000, -0.382683),
+        Vector3::new(-0.831470, -1.000000, -0.555570),
+        Vector3::new(-0.707107, -1.000000, -0.707107),
+        Vector3::new(-0.555570, -1.000000, -0.831470),
+        Vector3::new(-0.382683, -1.000000, -0.923880),
+        Vector3::new(-0.195090, -1.000000, -0.980785),
+        Vector3::new(0.000000, 1.000000, 0.000000),
+    ]
+    .into_iter()
+    .map(|v| v.push(0.))
+    .collect()
+}
+
+pub fn triangles() -> Vec<Triangle> {
+    vec![
+        Triangle { a: 31, b: 0, c: 1 },
+        Triangle { a: 1, b: 2, c: 3 },
+        Triangle { a: 3, b: 4, c: 5 },
+        Triangle { a: 5, b: 6, c: 7 },
+        Triangle { a: 7, b: 8, c: 9 },
+        Triangle { a: 9, b: 10, c: 11 },
+        Triangle {
+            a: 11,
+            b: 12,
+            c: 13,
+        },
+        Triangle {
+            a: 13,
+            b: 14,
+            c: 15,
+        },
+        Triangle {
+            a: 15,
+            b: 16,
+            c: 17,
+        },
+        Triangle {
+            a: 17,
+            b: 18,
+            c: 19,
+        },
+        Triangle {
+            a: 19,
+            b: 20,
+            c: 21,
+        },
+        Triangle {
+            a: 21,
+            b: 22,
+            c: 23,
+        },
+        Triangle {
+            a: 23,
+            b: 24,
+            c: 25,
+        },
+        Triangle {
+            a: 25,
+            b: 26,
+            c: 27,
+        },
+        Triangle {
+            a: 27,
+            b: 28,
+            c: 29,
+        },
+        Triangle {
+            a: 29,
+            b: 30,
+            c: 31,
+        },
+        Triangle { a: 31, b: 1, c: 7 },
+        Triangle { a: 1, b: 3, c: 7 },
+        Triangle { a: 3, b: 5, c: 7 },
+        Triangle { a: 7, b: 9, c: 15 },
+        Triangle { a: 9, b: 11, c: 15 },
+        Triangle {
+            a: 11,
+            b: 13,
+            c: 15,
+        },
+        Triangle {
+            a: 15,
+            b: 17,
+            c: 23,
+        },
+        Triangle {
+            a: 17,
+            b: 19,
+            c: 23,
+        },
+        Triangle {
+            a: 19,
+            b: 21,
+            c: 23,
+        },
+        Triangle {
+            a: 23,
+            b: 25,
+            c: 31,
+        },
+        Triangle {
+            a: 25,
+            b: 27,
+            c: 31,
+        },
+        Triangle {
+            a: 27,
+            b: 29,
+            c: 31,
+        },
+        Triangle { a: 31, b: 7, c: 15 },
+        Triangle {
+            a: 15,
+            b: 23,
+            c: 31,
+        },
+        Triangle { a: 0, b: 32, c: 1 },
+        Triangle { a: 1, b: 32, c: 2 },
+        Triangle { a: 2, b: 32, c: 3 },
+        Triangle { a: 3, b: 32, c: 4 },
+        Triangle { a: 4, b: 32, c: 5 },
+        Triangle { a: 5, b: 32, c: 6 },
+        Triangle { a: 6, b: 32, c: 7 },
+        Triangle { a: 7, b: 32, c: 8 },
+        Triangle { a: 8, b: 32, c: 9 },
+        Triangle { a: 9, b: 32, c: 10 },
+        Triangle {
+            a: 10,
+            b: 32,
+            c: 11,
+        },
+        Triangle {
+            a: 11,
+            b: 32,
+            c: 12,
+        },
+        Triangle {
+            a: 12,
+            b: 32,
+            c: 13,
+        },
+        Triangle {
+            a: 13,
+            b: 32,
+            c: 14,
+        },
+        Triangle {
+            a: 14,
+            b: 32,
+            c: 15,
+        },
+        Triangle {
+            a: 15,
+            b: 32,
+            c: 16,
+        },
+        Triangle {
+            a: 16,
+            b: 32,
+            c: 17,
+        },
+        Triangle {
+            a: 17,
+            b: 32,
+            c: 18,
+        },
+        Triangle {
+            a: 18,
+            b: 32,
+            c: 19,
+        },
+        Triangle {
+            a: 19,
+            b: 32,
+            c: 20,
+        },
+        Triangle {
+            a: 20,
+            b: 32,
+            c: 21,
+        },
+        Triangle {
+            a: 21,
+            b: 32,
+            c: 22,
+        },
+        Triangle {
+            a: 22,
+            b: 32,
+            c: 23,
+        },
+        Triangle {
+            a: 23,
+            b: 32,
+            c: 24,
+        },
+        Triangle {
+            a: 24,
+            b: 32,
+            c: 25,
+        },
+        Triangle {
+            a: 25,
+            b: 32,
+            c: 26,
+        },
+        Triangle {
+            a: 26,
+            b: 32,
+            c: 27,
+        },
+        Triangle {
+            a: 27,
+            b: 32,
+            c: 28,
+        },
+        Triangle {
+            a: 28,
+            b: 32,
+            c: 29,
+        },
+        Triangle {
+            a: 29,
+            b: 32,
+            c: 30,
+        },
+        Triangle {
+            a: 30,
+            b: 32,
+            c: 31,
+        },
+        Triangle { a: 31, b: 32, c: 0 },
+    ]
+}

--- a/rust/crates/gpu/src/lib.rs
+++ b/rust/crates/gpu/src/lib.rs
@@ -6,6 +6,8 @@
 // license that can be found in the LICENSE_MIT file or at
 // https://opensource.org/licenses/MIT.
 
+#![recursion_limit = "256"]
+
 pub use wgpu;
 pub use wgpu_profiler;
 
@@ -99,6 +101,8 @@ pub use test_status::TestStatus;
 pub use test_svd::TestSvd;
 pub use viscosity::Viscosity;
 
+#[cfg(test)]
+mod cone;
 #[cfg(test)]
 mod test_util;
 #[cfg(test)]

--- a/rust/crates/gpu/src/shaders/compute_vertex_normals.wesl
+++ b/rust/crates/gpu/src/shaders/compute_vertex_normals.wesl
@@ -6,7 +6,7 @@
 // license that can be found in the LICENSE_MIT file or at
 // https://opensource.org/licenses/MIT.
 
-import super::util::{get_global_index, try_normalize};
+import super::util::{get_global_index, try_normalize, Triangle};
 
 @group(0) @binding(0)
 var<storage, read_write> vertex_triangle_offsets: array<u32>;
@@ -15,12 +15,18 @@ var<storage, read_write> vertex_triangle_offsets: array<u32>;
 var<storage, read_write> vertex_triangle_lists: array<u32>;
 
 @group(0) @binding(2)
-var<storage, read_write> vertex_normals: array<vec3f>;
+var<storage, read_write> vertex_positions: array<vec3f>;
 
 @group(0) @binding(3)
-var<storage, read_write> triangle_normals: array<vec3f>;
+var<storage, read_write> vertex_normals: array<vec3f>;
 
 @group(0) @binding(4)
+var<storage, read_write> triangle_indices: array<Triangle>;
+
+@group(0) @binding(5)
+var<storage, read_write> triangle_normals: array<vec3f>;
+
+@group(0) @binding(6)
 var<storage, read_write> status: atomic<u32>;
 
 override WORKGROUP_SIZE: u32;
@@ -50,7 +56,34 @@ fn main(
 
     var normal = vec3f(0.);
     for (var lookup = triangle_start; lookup < triangle_end; lookup++) {
-        normal += triangle_normals[vertex_triangle_lists[lookup]];
+
+        let triangle_index = vertex_triangle_lists[lookup];
+        let triangle = triangle_indices[triangle_index];
+
+        var ap = vec3f(0.);
+        var bp = vec3f(0.);
+        let a = vertex_positions[triangle.a];
+        let b = vertex_positions[triangle.b];
+        let c = vertex_positions[triangle.c];
+        if global_index == triangle.a {
+            ap = b - a;
+            bp = c - a;
+        } else if global_index == triangle.b {
+            ap = c - b;
+            bp = a - b;
+        } else {
+            ap = a - c;
+            bp = b - c;
+        }
+
+        let ll = length(ap) * length(bp);
+        if ll == 0. {
+            continue;
+        }
+
+        let angle = acos(clamp(dot(ap, bp) / ll, -1., 1.));
+
+        normal += angle * triangle_normals[triangle_index];
     }
 
     vertex_normals[global_index] = try_normalize(normal, vec3f(0.));


### PR DESCRIPTION
The vertex normals need to be more accurate, this PR adds angle-weighting to improve the accuracy.

If they are biased to one side too much, there can be volumes that are classified to be on the wrong side.
Extreme example:
<img width="658" height="433" alt="bitmap" src="https://github.com/user-attachments/assets/d029ddee-cbba-4b58-8c25-bb5d379944d7" />

If the collider has sharper angles, a relatively small error in the normal can lead to large volumes being wrongly classified.

Towards fixing the benchmark scene, aka #313 