### PR TITLE
Io icons

### DIFF
--- a/python/src/squishy_volumes_extension/panels/panel_input.py
+++ b/python/src/squishy_volumes_extension/panels/panel_input.py
@@ -235,7 +235,12 @@ class SCENE_UL_Squishy_Volumes_Input_Object_List(bpy.types.UIList):
         flt_flag,
     ):
         assert isinstance(item, bpy.types.Object)
-        layout.label(text=item.name)
+        icon = "QUESTION"
+        if item.squishy_volumes.input_type == INPUT_TYPE_PARTICLES:
+            icon = "OUTLINER_OB_POINTCLOUD"
+        if item.squishy_volumes.input_type == INPUT_TYPE_COLLIDER:
+            icon = "MOD_PHYSICS"
+        layout.label(text=item.name, icon=icon)
 
 
 class SCENE_PT_Squishy_Volumes_Input(bpy.types.Panel):

--- a/python/src/squishy_volumes_extension/panels/panel_output.py
+++ b/python/src/squishy_volumes_extension/panels/panel_output.py
@@ -380,7 +380,12 @@ class SCENE_UL_Squishy_Volumes_Output_Object_List(bpy.types.UIList):
         flt_flag,
     ):
         assert isinstance(item, bpy.types.Object)
-        layout.label(text=item.name)
+        icon = "QUESTION"
+        if item.squishy_volumes.output_type == PARTICLES:
+            icon = "OUTLINER_OB_POINTCLOUD"
+        if item.squishy_volumes.output_type == GRID:
+            icon = "MESH_GRID"
+        layout.label(text=item.name, icon=icon)
 
 
 class SCENE_PT_Squishy_Volumes_Output(bpy.types.Panel):


### PR DESCRIPTION
Fixes #337
Just some cute icons to tell which type the input/output objects have:

<img width="324" height="527" alt="Screenshot from 2026-09-08 17-05-32" src="https://github.com/user-attachments/assets/28a7e15f-499b-4584-bc9d-207ffc6daf12" />
